### PR TITLE
CoC Committee -> SC

### DIFF
--- a/conduct/enforcement.md
+++ b/conduct/enforcement.md
@@ -7,20 +7,12 @@ and fair.
 ## The Code of Conduct Committee
 
 All responses to reports of conduct violations will be managed by a Code of
-Conduct Committee ("the committee"), currently comprised of
-[*note:* still gathering volunteers, this will be filled in as they become available and prior to final upload into the rendered site]:
-
-* Person One foo@email (Chair of the Committee)
-* ...
-* Person Five bar@email
-
-The Jupyter Steering Council will approve the members of this five person
-committee. The members will be drawn from our entire community, and we intend
-that it *not* be only Steering Council members: anyone who is actively engaged
-with Jupyter can propose to join this committee (we'll explicitly solicit
-volunteers when short of five members).  One member will be designated chair of
-the group and will be responsible for all reports back to the Steering Council.
-
+Conduct Committee ("the committee"). The Code of Conduct Committee is current
+the Jupyter Steering Council. The Steering Council may appoint a subcommittee or
+consult with outside parties in its handling of particular Code of Coduct cases.
+If a Code of Conduct violation report is initiated against a member of the
+Steering Council, that individual will not participate in the enforcement
+process or decisions.
 
 ## Enforcement guidelines and principles
 

--- a/conduct/enforcement.md
+++ b/conduct/enforcement.md
@@ -1,18 +1,21 @@
 # Jupyter Code of Conduct - Enforcement Manual
 
-This is the enforcement manual followed by Jupyter's Code of Conduct
-Committee. It's used when we respond to an issue to make sure we're consistent
-and fair.
+This is the enforcement manual followed by Jupyter's Code of Conduct Committee.
+It's used when we respond to an incident to make sure we are consistent and
+fair.
 
 ## The Code of Conduct Committee
 
 All responses to reports of conduct violations will be managed by a Code of
-Conduct Committee ("the committee"). The Code of Conduct Committee is current
-the Jupyter Steering Council. The Steering Council may appoint a subcommittee or
-consult with outside parties in its handling of particular Code of Coduct cases.
-If a Code of Conduct violation report is initiated against a member of the
-Steering Council, that individual will not participate in the enforcement
-process or decisions.
+Conduct Committee ("the committee"). The Jupyter Steering Council is responsible
+for vetting and appointing the Code of Conduct Committee. During periods where
+a separate Code of Conduct Committee is not appointed or is not available
+to handle a code of conduct report promptly, the Jupyter Steering Council
+will serve as the interim Code of Conduct Committee.
+
+If a Code of Conduct report involves a member of the Steering Council or Code of
+Conduct Committee, that member will not participate in the investigation or any
+decisions related to that report.
 
 ## Enforcement guidelines and principles
 


### PR DESCRIPTION
In this PR, I propose that for now we make the CoC Committee the entire Jupyter Steering Council. The language added here does allow the SC to appoint a subcommittee or consult with outside parties in particular cases.

The motivations for this change are:

* The CoC Committee has the potential to make high stakes decisions with legal ramifications for contributors and their employers.
* Members of the CoC Committee need the highest level of responsibility, authority in the project and currently, that sits with the Jupyter Steering Council.
* The high level of responsibility and authority required of CoC Committee members warrants a very clear process of election. The SC has such a process.

We may over time change this, but this gets us to a point where there is no ambiguity about our CoC being fully implemented.
