### PR TITLE
Remove political belief from JupyterDay CoC

### DIFF
--- a/CodeofConductJupyterDay.md
+++ b/CodeofConductJupyterDay.md
@@ -1,1 +1,86 @@
-# JupyterDay Code of ConductProject Jupyter is an engaged and respectful community made up of people fromall over the world. Your involvement helps us to further our mission andcreate an open platform that serves a broad range of communities, fromresearch and education to journalism, industry and beyond.At Project Jupyter and JupyterDay, we are committed to providing aharassment-free conference experience for everyone, regardless of gender,sexual orientation, disability, physical appearance, body size, race, orreligion. Conference organizers will not tolerate harassment of participantsin any form. Sexual language and imagery is not appropriate for any part ofthe conference venue, including talks.Be kind to others. Do not insult or put down other attendees. Behaveprofessionally. Remember that harassment and sexist, racist, orexclusionary jokes are not appropriate for Project Jupyter events.Attendees violating these rules may be asked to leave the conference withouta refund at the sole discretion of the conference organizers.Harassment includes, but is not limited to:* Offensive verbal comments related to race, ethnicity, culture, national  origin, color, immigration status, social and economic class, educational  level, sexual orientation, gender, gender identity and expression, age,  physical appearance, family status, political belief, religion, and mental  and physical disability.* Sexual images in public spaces* Deliberate intimidation, stalking, or following* Harassing photography or recording* Sustained disruption of talks or other events* Inappropriate physical contact* Unwelcome sexual attention* Advocating for, or encouraging, any of the above behaviorBy following the guidelines above and consistently and fairly resolvingany complaints we can make attending JupyterDay a welcoming event.## Enforcement* Participants asked to stop any harassing behavior are expected to comply  immediately.* If a participant engages in harassing behavior, event organizers retain  the right to take any actions to keep the event a welcoming environment  for all participants. This includes warning the offender or expulsion  from the conference with no refund.* Event organizers may take action to remedy or set right anything designed  to, or with the clear impact of, disrupting the event or making the  environment hostile for any participants.## ReportingIf someone makes you or any other conference participant feel unsafe orunwelcome, please report this as soon as possible. Code of conductviolations reduce the value of our event for everyone and we take them seriously.### Anonymous ReportYou can file an anonymous report here: http://goo.gl/forms/aQ8Wz4slfaWe can't follow up on an anonymous report with you directly, but we will takewhatever action is necessary to prevent a recurrence.### Personal ReportYou can make a personal report by:**Phone: Call or message:** [Insert Phone] This phone number will be monitored for the duration of the event.**In Person:** Contact a staff member, identified by STAFF badges.When taking a personal report, our staff will ensure you are safe and cannotbe overheard. They may involve other event staff to ensure your report ismanaged properly. This can be uncomfortable, but we'll handle it respectfullyand you can bring someone to support you.**Email:** Send a message to projectjupyter@gmail.com and/or [insert local organizer email]Our team will help you contact hotel/venue security, local law enforcement,local support services, provide escorts, or otherwise assist you to feel safefor the duration of the event.- **Email:** projectjupyter@gmail.com, [insert local organizer email]- **Conference organizer mobile:**- **Venue security:**- **Law enforcement:**- **Local sexual assault hot line:**- **Non-emergency medical (e.g., urgent care, day clinic):**- **Taxi:**
+# JupyterDay Code of Conduct
+
+Project Jupyter is an engaged and respectful community made up of people from
+all over the world. Your involvement helps us to further our mission and
+create an open platform that serves a broad range of communities, from
+research and education to journalism, industry and beyond.
+
+At Project Jupyter and JupyterDay, we are committed to providing a
+harassment-free conference experience for everyone, regardless of gender,
+sexual orientation, disability, physical appearance, body size, race, or
+religion. Conference organizers will not tolerate harassment of participants
+in any form. Sexual language and imagery is not appropriate for any part of
+the conference venue, including talks.
+
+Be kind to others. Do not insult or put down other attendees. Behave
+professionally. Remember that harassment and sexist, racist, or
+exclusionary jokes are not appropriate for Project Jupyter events.
+
+Attendees violating these rules may be asked to leave the conference without
+a refund at the sole discretion of the conference organizers.
+
+Harassment includes, but is not limited to:
+* Offensive verbal comments related to race, ethnicity, culture, national
+  origin, color, immigration status, social and economic class, educational
+  level, sexual orientation, gender, gender identity and expression, age,
+  physical appearance, family status, religion, and mental
+  and physical disability.
+* Sexual images in public spaces
+* Deliberate intimidation, stalking, or following
+* Harassing photography or recording
+* Sustained disruption of talks or other events
+* Inappropriate physical contact
+* Unwelcome sexual attention
+* Advocating for, or encouraging, any of the above behavior
+
+By following the guidelines above and consistently and fairly resolving
+any complaints we can make attending JupyterDay a welcoming event.
+
+## Enforcement
+* Participants asked to stop any harassing behavior are expected to comply
+  immediately.
+* If a participant engages in harassing behavior, event organizers retain
+  the right to take any actions to keep the event a welcoming environment
+  for all participants. This includes warning the offender or expulsion
+  from the conference with no refund.
+* Event organizers may take action to remedy or set right anything designed
+  to, or with the clear impact of, disrupting the event or making the
+  environment hostile for any participants.
+
+## Reporting
+If someone makes you or any other conference participant feel unsafe or
+unwelcome, please report this as soon as possible. Code of conduct
+violations reduce the value of our event for everyone and we take them seriously.
+
+### Anonymous Report
+You can file an anonymous report here: http://goo.gl/forms/aQ8Wz4slfa
+
+We can't follow up on an anonymous report with you directly, but we will take
+whatever action is necessary to prevent a recurrence.
+
+### Personal Report
+You can make a personal report by:
+
+**Phone: Call or message:** [Insert Phone] This phone number will be monitored 
+for the duration of the event.
+
+**In Person:** Contact a staff member, identified by STAFF badges.
+
+When taking a personal report, our staff will ensure you are safe and cannot
+be overheard. They may involve other event staff to ensure your report is
+managed properly. This can be uncomfortable, but we'll handle it respectfully
+and you can bring someone to support you.
+
+**Email:** Send a message to projectjupyter@gmail.com and/or [insert local organizer email]
+
+Our team will help you contact hotel/venue security, local law enforcement,
+local support services, provide escorts, or otherwise assist you to feel safe
+for the duration of the event.
+
+- **Email:** projectjupyter@gmail.com, [insert local organizer email]
+- **Conference organizer mobile:**
+- **Venue security:**
+- **Law enforcement:**
+- **Local sexual assault hot line:**
+- **Non-emergency medical (e.g., urgent care, day clinic):**
+- **Taxi:**


### PR DESCRIPTION
Political Affiliation is something you do (and choose), it's not something you are. It is not the same as a protected class.

---

It also looks like github autocorrected line feeds when I made this edit from the UI.