### PR TITLE
Remove political belief from CoC

### DIFF
--- a/conduct/code_of_conduct.md
+++ b/conduct/code_of_conduct.md
@@ -56,7 +56,7 @@ free to contact the Code of Conduct Committee at
    to, members of any race, ethnicity, culture, national origin, color,
    immigration status, social and economic class, educational level, sex, sexual
    orientation, gender identity and expression, age, physical appearance, family
-   status, political belief, technological or professional choices, academic
+   status, technological or professional choices, academic
    discipline, religion, mental ability, and physical ability.
 
 3. **Be considerate**. Your work will be used by other people, and you in turn


### PR DESCRIPTION
The Jupyter Steering council is proposing to remove the phrase “political belief” from our Code of Conduct. This is being proposed because the phrase is overly vague and likely harmful. In particular, we want to make it clear that this change is meant to indicate that one can still be sanctioned for e.g. sexist or racist behavior even if it is due to a "political belief". Discriminatory views are not welcome.

Editing to add in relevant quotes from discussion below:

@ivanov:

> This code of conduct is not about legal rights - we are not trying to establish legal precedent. This is about tone and expectations and communicating the intent to create a welcoming environment. In short, we do not wish to prioritize or elevate any members of a particular political belief to the same level as any members of the examples remaining in the document.

@SylvainCorlay:

> Racism and sexism are becoming more and more "mainstream political beliefs".

> This change is meant to indicate that one can still be sanctioned for e.g. sexist or racist behavior even if it is due to a "political belief".