### PR TITLE
Update license guidelines for projects

### DIFF
--- a/projectlicense.md
+++ b/projectlicense.md
@@ -32,26 +32,17 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-## About the Jupyter Development Team
+## Explanation of Project Jupyter copyright policy
 
-The Jupyter Development Team is the set of all contributors to the Jupyter project.
-This includes all of the Jupyter Subprojects, which are the different repositories
-under the [jupyter](https://github.com/jupyter/) GitHub organization.
-
-The core team that coordinates development on GitHub can be found here:
-https://github.com/jupyter/.
-
-## Our copyright policy
-
-Jupyter uses a shared copyright model. Each contributor maintains copyright
-over their contributions to Jupyter. But, it is important to note that these
-contributions are typically only changes to the repositories. Thus, the Jupyter
-source code, in its entirety is not the copyright of any single person or
-institution.  Instead, it is the collective copyright of the entire Jupyter
-Development Team.  If individual contributors want to maintain a record of what
-changes/contributions they have specific copyright on, they should indicate
-their copyright in the commit message of the change, when they commit the
-change to one of the Jupyter repositories.
+Project Jupyter uses a shared copyright model. Each contributor maintains
+copyright over their contributions to Project Jupyter. These contributions are
+typically only changes to the repositories. Thus, Project Jupyter source code,
+in its entirety, is not the copyright of any single person or institution.
+Instead, Project Jupyter source code is the collective copyright of its
+contributors. If individual contributors want to maintain a record of what
+changes or contributions they have specific copyright on, they should indicate
+their copyright in the commit message of the change when they commit the
+change to one of the Project Jupyter repositories.
 
 With this in mind, the following banner should be used in any source code file
 to indicate the copyright and license terms:

--- a/projectlicense.md
+++ b/projectlicense.md
@@ -1,31 +1,30 @@
 # Licensing terms
 
-This project is licensed under the terms of the Modified BSD License
-(also known as New or Revised or 3-Clause BSD), as follows:
+This project is licensed under the terms of the 3-Clause BSD License (also
+known as New or Revised or Modified BSD License, or the BSD-3-Clause license),
+as follows:
 
-- Copyright (c) 2001-2015, IPython Development Team
-- Copyright (c) 2015-, Jupyter Development Team
-
+Copyright (c) YEAR Project Jupyter Contributors.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-Redistributions of source code must retain the above copyright notice, this
-list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-Redistributions in binary form must reproduce the above copyright notice, this
-list of conditions and the following disclaimer in the documentation and/or
-other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-Neither the name of the Jupyter Development Team nor the names of its
-contributors may be used to endorse or promote products derived from this
-software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
 FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
 SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
@@ -57,5 +56,5 @@ change to one of the Jupyter repositories.
 With this in mind, the following banner should be used in any source code file
 to indicate the copyright and license terms:
 
-    # Copyright (c) Jupyter Development Team.
-    # Distributed under the terms of the Modified BSD License.
+    # Copyright (c) Project Jupyter Contributors.
+    # Distributed under the terms of the 3-Clause BSD License.


### PR DESCRIPTION
This follows up on conversation in https://github.com/jupyter/governance/issues/37 and the [mailing list discussion](https://groups.google.com/forum/#!topic/jupyter/vZpWgw8zKdc) about updating our project license and copyright terms to be more clear and conform better to the opensource.org and spdx BSD license pages.

Fixes #37 

## Summary of updates

* Update primary license name to 3-Clause BSD License to reflect the opensource.org and spdx.org primary names for the license

* Make copyright owner “Project Jupyter Contributors” to reflect discussion in the mailing list thread. We do not view this as a change, but rather as a clarification of our shared copyright model.

* Wrap all lines to 78 or fewer characters

* Update BSD conditions to be enumerated with numbers, following the text on opensource.org and spdx.org

* In condition 3, replace “Jupyter Development Team” with the exact license text “copyright holder”.

* We previously had, in the disclaimer section, a sentence starting with “IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS…”. OWNER is now replaced with HOLDER, to reflect the license text on opensource.org and spdx.org

* Update the per-file license statement with “Project Jupyter Contributors” and “3-Clause BSD License” terminology.

I also edited our copyright policy explanation for grammar and to clarify that for a particular project, its copyright is shared by its contributors (not necessarily *all* Jupyter contributors).