### PR TITLE
adding an action step to enforcement guide

### DIFF
--- a/conduct/code_of_conduct.md
+++ b/conduct/code_of_conduct.md
@@ -110,7 +110,7 @@ If any community member deems the action to be harmful to the community,
 they may act immediately to defuse the situation.
 This includes actions directed at the situation, rather than at an individual, such
 as locking a thread, *temporarily* suspending a user's account in the
-community forum, calling a meeting break, or generally engaging in actions
+community forum, calling a meeting break, or generally acting to
 de-escalate the situation.
 If the action is ongoing or requires a response directed at a specific individual,
 then the incident should be [reported to the CoC committee](#Reporting).

--- a/conduct/code_of_conduct.md
+++ b/conduct/code_of_conduct.md
@@ -39,7 +39,8 @@ Reporting Guidelines (for [online](reporting_online.md) and
 This code applies equally to founders, developers, mentors and new community
 members, in all spaces managed by Project Jupyter (including IPython). This
 includes the mailing lists, our GitHub organizations, our chat rooms, in-person
-events, community forum, and any other forums created by the project team. In addition,
+events, the [Discourse community forum](https://discourse.jupyter.org),
+and any other forums created by the project team. In addition,
 violations of this code outside these spaces may affect a person's ability to
 participate within them.
 

--- a/conduct/code_of_conduct.md
+++ b/conduct/code_of_conduct.md
@@ -123,7 +123,7 @@ or other local personnel that are present.
 
 In situations where an individual community member acts unilaterally,
 they must inform the Code of Conduct committee as soon as possible,
-and report their actions for review by e-mailing
+by e-mailing
 [*conduct@jupyter.org*](mailto:conduct@jupyter.org)*reporting_online.md*)
 within 24 hours.
 

--- a/conduct/code_of_conduct.md
+++ b/conduct/code_of_conduct.md
@@ -115,7 +115,7 @@ de-escalate the situation. Follow-up your actions by
 [reporting the incident to the CoC committee](#Reporting).
 
 If the incident involves physical danger, or involves a threat to anyone's safety
-(e.g. threats of violence), any member of the community may -- and should -- act
+(such as threats of violence), any member of the community may -- and should -- act
 unilaterally to protect the safety of any community member.
 This can include contacting law enforcement, other members of the Jupyter community,
 or other local personnel that are present.

--- a/conduct/code_of_conduct.md
+++ b/conduct/code_of_conduct.md
@@ -111,9 +111,8 @@ they may act immediately to defuse the situation.
 This includes actions directed at the situation, rather than at an individual, such
 as locking a thread, *temporarily* suspending a user's account in the
 community forum, calling a meeting break, or generally acting to
-de-escalate the situation.
-If the action is ongoing or requires a response directed at a specific individual,
-then the incident should be [reported to the CoC committee](#Reporting).
+de-escalate the situation. Follow-up your actions by
+[reporting the incident to the CoC committee](#Reporting).
 
 If the incident involves physical danger, or involves a threat to anyone's safety
 (e.g. threats of violence), any member of the community may -- and should -- act

--- a/conduct/code_of_conduct.md
+++ b/conduct/code_of_conduct.md
@@ -111,7 +111,7 @@ they may act immediately to defuse the situation.
 This includes actions directed at the situation, rather than at an individual, such
 as locking a thread, *temporarily* suspending a user's account in the
 community forum, calling a meeting break, or generally engaging in actions
-aimed at de-escalating the situation.
+de-escalate the situation.
 If the action is ongoing or requires a response directed at a specific individual,
 then the incident should be [reported to the CoC committee](#Reporting).
 

--- a/conduct/code_of_conduct.md
+++ b/conduct/code_of_conduct.md
@@ -39,15 +39,16 @@ Reporting Guidelines (for [online](reporting_online.md) and
 This code applies equally to founders, developers, mentors and new community
 members, in all spaces managed by Project Jupyter (including IPython). This
 includes the mailing lists, our GitHub organizations, our chat rooms, in-person
-events, and any other forums created by the project team. In addition,
+events, community forum, and any other forums created by the project team. In addition,
 violations of this code outside these spaces may affect a person's ability to
 participate within them.
+
+## Expected behavior
 
 By embracing the following principles, guidelines and actions to follow or
 avoid, you will help us make Jupyter a welcoming and productive community. Feel
 free to contact the Code of Conduct Committee at
 [*conduct@jupyter.org*](mailto:conduct@jupyter.org) with any questions.
-
 
 1. **Be friendly and patient**.
 
@@ -100,6 +101,31 @@ free to contact the Code of Conduct Committee at
 8. **A simple apology can go a long way**. It can often de-escalate a situation,
    and telling someone that you are sorry is an act of empathy that doesn’t
    automatically imply an admission of guilt.
+
+
+## Responding to inappropriate behavior
+
+In some cases, individuals may violate the CoC in online or in-person situations.
+If any community member deems the action to be harmful to the community,
+they may act immediately to defuse the situation.
+This includes actions directed at the situation, rather than at an individual, such
+as locking a thread, *temporarily* suspending a user's account in the
+community forum, calling a meeting break, or generally engaging in actions
+aimed at de-escalating the situation.
+If the action is ongoing or requires a response directed at a specific individual,
+then the incident should be [reported to the CoC committee](#Reporting).
+
+If the incident involves physical danger, or involves a threat to anyone's safety
+(e.g. threats of violence), any member of the community may -- and should -- act
+unilaterally to protect the safety of any community member.
+This can include contacting law enforcement, other members of the Jupyter community,
+or other local personnel that are present.
+
+In situations where an individual community member acts unilaterally,
+they must inform the Code of Conduct committee as soon as possible,
+and report their actions for review by e-mailing
+[*conduct@jupyter.org*](mailto:conduct@jupyter.org)*reporting_online.md*)
+within 24 hours.
 
 
 ## Reporting

--- a/conduct/enforcement.md
+++ b/conduct/enforcement.md
@@ -1,7 +1,6 @@
 # Jupyter Code of Conduct - Enforcement Manual
 
-This is the enforcement manual followed by Jupyter's core contributors,
-as well as Jupyter's Code of Conduct Committee.
+This is the enforcement manual followed by Jupyter's Code of Conduct Committee.
 It's used when we respond to an incident to make sure we are consistent and
 fair.
 
@@ -82,32 +81,6 @@ satisfactory to all.  Upon completion, the mediator will provide a report
 on further steps.  The Committee will then evaluate these results (whether
 satisfactory resolution was achieved or not) and decide on any additional
 action deemed necessary.
-
-
-## Acting unilaterally
-
-In some cases, individuals may violate the CoC in online or in-person situations.
-If any community member deems the action to be harmful to the community,
-they may act immediately, before reaching consensus, to defuse the situation.
-This includes actions directed at the situation, rather than at an individual, such
-as locking a thread, *temporarily* suspending a user's account in the
-community forum, calling a meeting break, or generally engaging in actions
-aimed at de-escalating the situation.
-If the action is ongoing or requires a response directed at a specific individual,
-then the incident should be reported to the CoC committee.
-
-If the incident involves physical danger, or involves a threat to anyone's safety
-(e.g. threats of violence), any member of the community may -- and should -- act
-unilaterally to protect the safety of any community member.
-This can include contacting law enforcement, other members of the Jupyter community,
-r other local personnel that are present.
-
-In situations where an individual community member acts unilaterally,
-they must inform the Code of Conduct committee as soon as possible,
-and report their actions for review by e-mailing
-[*conduct@jupyter.org*](mailto:conduct@jupyter.org)*reporting_online.md*)
-within 24 hours.
-
 
 ## How the committee will respond to reports
 

--- a/conduct/enforcement.md
+++ b/conduct/enforcement.md
@@ -88,7 +88,7 @@ action deemed necessary.
 
 In some cases, individuals may violate the CoC in online or in-person situations.
 If any community member deems the action to be harmful to the community,
-they may act immediately, before reaching consensus, to diffuse the situation.
+they may act immediately, before reaching consensus, to defuse the situation.
 In ongoing situations, any member may at their discretion employ any of the
 tools available in this enforcement manual, including bans and blocks online,
 or removal from a physical space.

--- a/conduct/enforcement.md
+++ b/conduct/enforcement.md
@@ -1,6 +1,7 @@
 # Jupyter Code of Conduct - Enforcement Manual
 
-This is the enforcement manual followed by Jupyter's Code of Conduct Committee.
+This is the enforcement manual followed by Jupyter's core contributors,
+as well as Jupyter's Code of Conduct Committee.
 It's used when we respond to an incident to make sure we are consistent and
 fair.
 
@@ -81,6 +82,28 @@ satisfactory to all.  Upon completion, the mediator will provide a report
 on further steps.  The Committee will then evaluate these results (whether
 satisfactory resolution was achieved or not) and decide on any additional
 action deemed necessary.
+
+
+## Acting unilaterally
+
+In some cases, individuals may violate the CoC in online or in-person situations.
+If any community member deems the action to be harmful to the community,
+they may act immediately, before reaching consensus, to diffuse the situation.
+In ongoing situations, any member may at their discretion employ any of the
+tools available in this enforcement manual, including bans and blocks online,
+or removal from a physical space.
+
+If the incident involves physical danger, or involves a threat to anyone's safety
+(e.g. threats of violence), any member of the community may -- and should -- act
+unilaterally to protect the safety of any community member.
+This can include contacting law enforcement (or other local personnel) and
+speaking on behalf of the Jupyter Project.
+
+In situations where an individual community member acts unilaterally,
+they must inform the Code of Conduct committee as soon as possible,
+and report their actions for review by e-mailing
+[*conduct@jupyter.org*](mailto:conduct@jupyter.org)*reporting_online.md*)
+within 24 hours.
 
 
 ## How the committee will respond to reports

--- a/conduct/enforcement.md
+++ b/conduct/enforcement.md
@@ -89,15 +89,18 @@ action deemed necessary.
 In some cases, individuals may violate the CoC in online or in-person situations.
 If any community member deems the action to be harmful to the community,
 they may act immediately, before reaching consensus, to defuse the situation.
-In ongoing situations, any member may at their discretion employ any of the
-tools available in this enforcement manual, including bans and blocks online,
-or removal from a physical space.
+This includes actions directed at the situation, rather than at an individual, such
+as locking a thread, *temporarily* suspending a user's account in the
+community forum, calling a meeting break, or generally engaging in actions
+aimed at de-escalating the situation.
+If the action is ongoing or requires a response directed at a specific individual,
+then the incident should be reported to the CoC committee.
 
 If the incident involves physical danger, or involves a threat to anyone's safety
 (e.g. threats of violence), any member of the community may -- and should -- act
 unilaterally to protect the safety of any community member.
-This can include contacting law enforcement (or other local personnel) and
-speaking on behalf of the Jupyter Project.
+This can include contacting law enforcement, other members of the Jupyter community,
+r other local personnel that are present.
 
 In situations where an individual community member acts unilaterally,
 they must inform the Code of Conduct committee as soon as possible,


### PR DESCRIPTION
This adds a bit of language to the enforcement guide that explicitly empowers members of the community to diffuse situations if there is any behavior that violates the code of conduct. It also requires that, in these cases, the incident and what happened to diffuse it is communicated to the CoC committee.

The language was largely inspired by the [Turing Way CoC](https://github.com/alan-turing-institute/the-turing-way/blob/master/CODE_OF_CONDUCT.md#4-enforcement-manual). Thanks to @KirstieJane and that community for putting together a great CoC :-)

I'm open to feedback and thoughts on this!

Note: I also opened up https://github.com/jupyter/governance/issues/70 to discuss adding some more language about "unacceptable behaviors", but I didn't want to complicate this PR with it. If people are +1 on it, I am happy to make a new PR with that language or add it to this PR

closes https://github.com/jupyter/governance/issues/68


(edit: from https://github.com/jupyter/enhancement-proposals/pull/44, it seems like this needs to be a full SC vote? I'll add everybody's names below to see who has voted on this)

## Voting

Here is a list of SC members and their votes on this:

- [x] @afshin
- [x] @blink1073
- [x] @Carreau
- [x] @damianavila
- [x] @ellisonbg
- [x] @fperez
- [x] @ivanov
- [ ] @jasongrout
- [x] @jhamrick
- [x] @minrk
- [x] @mpacer
- [x] @parente
- [x] @rgbkrk
- [x] @Ruv7
- [x] @SylvainCorlay
- [ ] @takluyver
- [x] @willingc
