### PR TITLE
minimal changes to host governance docs online

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             - cache-pip
 
       - run: |
-          pip install -U "jupyter-book>=0.7.0b"
+          pip install -U git+https://github.com/executablebooks/jupyter-book.git
       - save_cache:
           key: cache-pip
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+version: 2
+jobs:
+  build_docs:
+    docker:
+      - image: circleci/python:3.6-stretch
+    steps:
+      # Get our data and merge with upstream
+      - run: sudo apt-get update
+      - checkout
+
+      - restore_cache:
+          keys:
+            - cache-pip
+
+      - run: |
+          pip install -U "jupyter-book>=0.7.0b"
+      - save_cache:
+          key: cache-pip
+          paths:
+            - ~/.cache/pip
+
+      # Build the docs
+      - run:
+          name: Build docs to store
+          command: |
+            jb build .
+
+      - store_artifacts:
+          path: _build/html/
+          destination: html
+
+
+workflows:
+  version: 2
+  default:
+    jobs:
+      - build_docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install -U "jupyter-book>=0.7.0b"
+        pip install -U git+https://github.com/executablebooks/jupyter-book.git
 
 
     # Build the book

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,37 @@
+name: deploy-book
+
+# Only run this when the master branch changes
+on:
+  push:
+    branches:
+    - master
+
+# This job installs dependencies, build the book, and pushes it to `gh-pages`
+jobs:
+  deploy-book:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # Install dependencies
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
+    - name: Install dependencies
+      run: |
+        pip install -U "jupyter-book>=0.7.0b"
+
+
+    # Build the book
+    - name: Build the book
+      run: |
+        jupyter-book build .
+
+    # Push the book's HTML to github-pages
+    - name: GitHub Pages action
+      uses: peaceiris/actions-gh-pages@v3.5.9
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./_build/html

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Docs
+_build

--- a/CodeofConductJupyterDayOrganizer.md
+++ b/CodeofConductJupyterDayOrganizer.md
@@ -1,4 +1,4 @@
-# JupyterDay Code of Conduct
+# JupyterDay Organizer Code of Conduct
 ## Procedures and Enforcement Guidelines
 
 The goal of this document is to continually improve the community and create a
@@ -8,10 +8,10 @@ to ensure attendees feel they are protected. When taking action on any report,
 consider:
 
 * The privacy and protection of the reporter are your first and foremost
-  concern. 
+  concern.
 * Try to understand context and intent to get the whole picture, but
   note that  lack of intent to harm is not an excuse, and still requires redress
-  to the injured party. 
+  to the injured party.
 * For language-based issues, find out if the reported party is a native English
   speaker.  It is very easy for a non-native speaker to make an innocent mistake
   they aren't even aware of, by transliteration or misuse of English words they
@@ -20,13 +20,13 @@ consider:
   the problem is.  A change of behavior may still be required, but a clarification
   of the language issue is more likely to produce benefit than purely punitive
   action. Stronger measures can still be  taken if the person continues to engage
- 
+
 ## Warnings
 
 Event Managers/Lead Organizers can issue a verbal warning to a participant that
 their behavior violates the conference's anti-harassment policy. Make clear to
 the participant that if they ignore the warning their participation in the event
-may not longer be welcome (in other words they may be expelled). 
+may not longer be welcome (in other words they may be expelled).
 
 Warnings should be reported to Ana Ruvalcaba via email ruv7.ana@gmail.com as
 soon as practical. The report should include:
@@ -57,13 +57,13 @@ presentation.
 
 When taking a report from someone experiencing harassment you should record what
 they say and reassure them they are being taken seriously, but avoid making
-specific promises about what actions the organizers will take. 
+specific promises about what actions the organizers will take.
 
 Ask for information if the reporter has not volunteered it (such as time, place)
 but do not pressure them to provide it if they are reluctant. Even if the report
 lacks important details such as the identity of the person taking the harassing
 actions, it should still be recorded and passed along to the appropriate staff
-member(s). 
+member(s).
 
 If the reporter requests additional support, you may assist them by asking for
 help from conference staff, a trusted person, contact a friend or contact local
@@ -79,7 +79,7 @@ A participant may be expelled by the decision of the Lead Organizer/Event
 Manager for whatever reasons they deem sufficient. However, here are some
 general guidelines for when a participant should be expelled:
 * A second offense resulting in an additional warning from Event Manager/Lead
-  Organizer 
+  Organizer
 * Continuing to harass after any "No" or "Stop" instruction
 * A pattern of harassing behavior, with or without warnings
 * A single serious offense (e.g., physical violence or groping someone)

--- a/README.md
+++ b/README.md
@@ -2,13 +2,35 @@
 
 The purpose of this repository is to formalize the governance process that the IPython/Jupyter project has used informally since its inception in 2001. This document clarifies how decisions are made and how the various elements of our community interact, including the relationship between open source collaborative development and work that may be funded by for-profit or non-profit entities.
 
+The governance documents are best-viewed at https://jupyter.org/governance
+
 ## Table of Contents
 
-* [Main Governance Document](governance)
-* [Current Steering Council and Institutional Partners](people)
-* [New Subproject Incubation Process](newsubprojects)
-* [Process for Authoring Jupyter Related Academic Papers](papers)
+* [Main Governance Document](governance.md)
+* [Current Steering Council and Institutional Partners](people.md)
+* [New Subproject Incubation Process](newsubprojects.md)
+* [Process for Authoring Jupyter Related Academic Papers](papers.md)
 
 ## License of Governance Documents
 
-To the extent possible under law, Project Jupyter has waived all copyright and related or neighboring rights to the Project Jupyter Governance documents, in accordance with the Creative Commons [CC0 license](http://creativecommons.org/publicdomain/zero/1.0/). This work is published from the United States.  See the LICENSE.md file in this repository for details.
+See [the governance introduction](intro.md) for license information.
+
+## Infrastructure for this repository
+
+The content in this repository is hosted online with `github-pages`, and the HTML
+files are built with [jupyter-book](https://jupyterbook.org). To build and preview
+these documents locally, install the latest version of Jupyter Book with:
+
+```
+pip install -U git+https://github.com/executablebooks/jupyter-book.git
+```
+
+and build the book with:
+
+```
+cd path/to/this/repo
+jupyter-book build .
+```
+
+The resulting website will be in `_build/html`, which you can explore by double-clicking
+any of the `.html` files that are created.

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ The purpose of this repository is to formalize the governance process that the I
 
 ## Table of Contents
 
-* [Main Governance Document](governance.md)
-* [Current Steering Council and Institutional Partners](people.md)
-* [New Subproject Incubation Process](newsubprojects.md)
-* [Process for Authoring Jupyter Related Academic Papers](papers.md)
+* [Main Governance Document](governance)
+* [Current Steering Council and Institutional Partners](people)
+* [New Subproject Incubation Process](newsubprojects)
+* [Process for Authoring Jupyter Related Academic Papers](papers)
 
 ## License of Governance Documents
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,22 @@
 title                       : Project Jupyter Governance
-exclude_patterns            : ["LICENSE.md"]
+exclude_patterns            : ["LICENSE.md", "README.md"]
 copyright: "2015"
 html:
   extra_footer: |
-    <div class="copyright">
-      Distributed under <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">this CC-0 license.</a>
-    </div>
+    <p xmlns:dct="http://purl.org/dc/terms/" xmlns:vcard="http://www.w3.org/2001/vcard-rdf/3.0#">
+      <a rel="license"
+        href="http://creativecommons.org/publicdomain/zero/1.0/">
+        <img src="https://licensebuttons.net/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+      </a>
+      <br />
+      To the extent possible under law,
+      <a rel="dct:publisher"
+        href="https://jupyter.org">
+        <span property="dct:title">Project Jupyter</span></a>
+      has waived all copyright and related or neighboring rights to
+      <a href="https://github.com/jupyter/governance"><span property="dct:title">Project Jupyter Governance Documents</span></a>.
+    This work is published from:
+    <span property="vcard:Country" datatype="dct:ISO3166"
+          content="US" about="https://jupyter.org">
+      United States</span>.
+    </p>

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
 title                       : Jupyter Governance
-author                      : The Jupyter Book community
+author                      : Project Jupyter
 copyright                   : "2020" 
 exclude_patterns            : ["LICENSE.md"]  

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,4 @@
+title                       : Jupyter Governance
+author                      : The Jupyter Book community
+copyright                   : "2020" 
+exclude_patterns            : ["LICENSE.md"]  

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title                       : Project Jupyter Governance
 exclude_patterns            : ["LICENSE.md", "README.md"]
-copyright: "2015"
+copyright: ""
 html:
   extra_footer: |
     <p xmlns:dct="http://purl.org/dc/terms/" xmlns:vcard="http://www.w3.org/2001/vcard-rdf/3.0#">
@@ -20,3 +20,7 @@ html:
           content="US" about="https://jupyter.org">
       United States</span>.
     </p>
+
+sphinx:
+  config:
+    html_show_copyright: false

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,8 @@
 title                       : Project Jupyter Governance
-author                      : Project Jupyter
-copyright                   : "2020" 
-exclude_patterns            : ["LICENSE.md"]  
+exclude_patterns            : ["LICENSE.md"]
+copyright: "2015"
+html:
+  extra_footer: |
+    <div class="copyright">
+      Distributed under <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">this CC-0 license.</a>
+    </div>

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-title                       : Jupyter Governance
+title                       : Project Jupyter Governance
 author                      : Project Jupyter
 copyright                   : "2020" 
 exclude_patterns            : ["LICENSE.md"]  

--- a/_toc.yml
+++ b/_toc.yml
@@ -2,11 +2,6 @@ file: README
 sections:
 - file: governance
 - file: conduct/code_of_conduct
-- file: people
-- file: newsubprojects
-- file: papers
-- file: trademarks
-- file: projectlicense
   sections:
   - file: conduct/enforcement
   - file: conduct/faq
@@ -14,4 +9,8 @@ sections:
   - file: conduct/reporting_online
   - file: CodeofConductJupyterDay
   - file: CodeofConductJupyterDayOrganizer
-  
+- file: people
+- file: newsubprojects
+- file: papers
+- file: trademarks
+- file: projectlicense

--- a/_toc.yml
+++ b/_toc.yml
@@ -1,4 +1,4 @@
-file: README
+file: intro
 sections:
 - file: governance
 - file: conduct/code_of_conduct

--- a/_toc.yml
+++ b/_toc.yml
@@ -1,12 +1,12 @@
 file: README
 sections:
 - file: governance
+- file: conduct/code_of_conduct
+- file: people
 - file: newsubprojects
 - file: papers
-- file: people
-- file: projectlicense
 - file: trademarks
-- file: conduct/code_of_conduct
+- file: projectlicense
   sections:
   - file: conduct/enforcement
   - file: conduct/faq

--- a/_toc.yml
+++ b/_toc.yml
@@ -1,0 +1,17 @@
+file: README
+sections:
+- file: governance
+- file: newsubprojects
+- file: papers
+- file: people
+- file: projectlicense
+- file: trademarks
+- file: conduct/code_of_conduct
+  sections:
+  - file: conduct/enforcement
+  - file: conduct/faq
+  - file: conduct/reporting_events
+  - file: conduct/reporting_online
+  - file: CodeofConductJupyterDay
+  - file: CodeofConductJupyterDayOrganizer
+  

--- a/conduct/code_of_conduct.md
+++ b/conduct/code_of_conduct.md
@@ -33,8 +33,8 @@ reasons, structured follow-up may be necessary and here we provide the means
 for that: we welcome reports by emailing
 [*conduct@jupyter.org*](mailto:conduct@jupyter.org) or by filling out [this
 form](https://goo.gl/forms/sJzOIie3zde9M71T2). For more details please see our
-Reporting Guidelines (for [online](reporting_online.md) and
-[in-person](reporting_events.md) contexts).
+Reporting Guidelines (for [online](reporting_online) and
+[in-person](reporting_events) contexts).
 
 This code applies equally to founders, developers, mentors and new community
 members, in all spaces managed by Project Jupyter (including IPython). This
@@ -124,7 +124,7 @@ or other local personnel that are present.
 In situations where an individual community member acts unilaterally,
 they must inform the Code of Conduct committee as soon as possible,
 by e-mailing
-[*conduct@jupyter.org*](mailto:conduct@jupyter.org)*reporting_online.md*)
+[*conduct@jupyter.org*](mailto:conduct@jupyter.org)*reporting_online*)
 within 24 hours.
 
 
@@ -148,7 +148,7 @@ report, we will take appropriate action.
 ## Enforcement
 
 For information on enforcement, please view the [*Enforcement
-Manual*](enforcement.md).
+Manual*](enforcement).
 
 Original text courtesy of the [*Speak
 Up!*](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html)

--- a/conduct/enforcement.md
+++ b/conduct/enforcement.md
@@ -88,7 +88,7 @@ When a report is sent to the committee they will immediately reply to the
 reporter to confirm receipt. This reply must be sent within 24 hours, and the
 group should strive to respond much quicker than that.
 
-See the [Reporting Guidelines](reporting_online.md) for details of
+See the [Reporting Guidelines](reporting_online) for details of
 what reports should contain. If a report doesn't contain enough information, the
 committee will obtain all relevant data before acting. The committee is
 empowered to act on the Steering Council’s behalf in contacting any individuals

--- a/conduct/faq.md
+++ b/conduct/faq.md
@@ -5,7 +5,7 @@ community's Code of Conduct. If you still have questions after reading it,
 please feel free to contact us at
 [*conduct@jupyter.org*](mailto:conduct@jupyter.org).
 
-### Why have you adopted a Code of Conduct?
+## Why have you adopted a Code of Conduct?
 
 We think the Jupyter community is awesome. If you're familiar with the Jupyter
 community, you'll probably notice that the Code basically matches what we
@@ -20,7 +20,7 @@ it's very important to be clear about our values.
 We know that the Jupyter community is open, friendly, and welcoming. We want to
 make sure everyone else knows it too.
 
-### What does it mean to "adopt" a Code of Conduct?
+## What does it mean to "adopt" a Code of Conduct?
 
 For the most part, we don't think it means large changes. We think that the text
 does a really good job describing the way the Jupyter community already conducts
@@ -35,16 +35,16 @@ it will apply both in community spaces and at our events.
 In practice, Jupyter spaces include mailing lists, various communication
 channels, and events.
 
-### What happens if someone violates the Code of Conduct?
+## What happens if someone violates the Code of Conduct?
 
 We are all stewards of our community, and are encouraged to participate in ways
 that defend the values highlighted in this document and help others understand
 when their actions go against these values (by engaging them and directing them
 to this document if necessary). If that doesn't work, or if you need more help,
 you can contact conduct@jupyter.org. For more details please see our [Reporting
-Guidelines](*reporting_online.md*).
+Guidelines](reporting_online).
 
-### What about events funded by Project Jupyter?
+## What about events funded by Project Jupyter?
 
 This Code of Conduct will also cover any events that Project Jupyter funds.
 
@@ -55,7 +55,7 @@ their participants.
 
 Event organizers will enforce the Code of Conduct.
 
-### Why do we need a Code of Conduct? Everyone knows not to be a jerk.
+## Why do we need a Code of Conduct? Everyone knows not to be a jerk.
 
 Sadly, not everyone knows this.
 
@@ -67,7 +67,7 @@ reminder to put our best foot forward. But most importantly, it serves as a
 signpost to people looking to join our community that we feel these values are
 important.
 
-### This is censorship! I have the right to say whatever I want!
+## This is censorship! I have the right to say whatever I want!
 
 You do -- in your space. If you'd like to hang out in our spaces, we have some
 simple guidelines to follow. If you want to, for example, form a group where

--- a/governance.md
+++ b/governance.md
@@ -6,8 +6,8 @@ section below, is contained in The Project Governance Repository at:
 
 [https://github.com/jupyter/governance](https://github.com/jupyter/governance)
 
-The Project
-===========
+## The Project
+
 
 The Jupyter/IPython Project (The Project) is an open source software project
 affiliated with the 501c3 NumFOCUS Foundation. The goal of The Project is to
@@ -57,8 +57,7 @@ manage project donations and acts as a parent legal entity. NumFOCUS is the
 only legal entity that has a formal relationship with the project (see
 Institutional Partners section below).
 
-Governance
-==========
+## Governance
 
 This section describes the governance and leadership model of The Project.
 
@@ -83,8 +82,7 @@ will consist of a BDFL and Steering Council. We view this governance model as
 the formalization of what we are already doing, rather than a change in
 direction.
 
-BDFL
-----
+### BDFL
 
 The Project will have a BDFL (Benevolent Dictator for Life), who is currently
 Fernando Perez. As Dictator, the BDFL has the authority to make all final
@@ -109,8 +107,7 @@ Main NumFOCUS Board. While the Steering Council and Main NumFOCUS Board will
 work together closely on the BDFL selection process, the Main NUMFOCUS Board
 will make the final decision.
 
-Steering Council
-----------------
+### Steering Council
 
 The Project will have a Steering Council that consists of Project Contributors
 who have produced contributions that are substantial in quality and quantity,
@@ -142,7 +139,7 @@ In particular, the Council may:
 -   Make decisions when regular community discussion doesn’t produce consensus
     on an issue in a reasonable time frame.
 
-### Council membership
+#### Council membership
 
 To become eligible for being a Steering Council Member an individual must be a
 Project Contributor who has produced contributions that are substantial in
@@ -180,7 +177,7 @@ The Council reserves the right to eject current Members, other than the BDFL,
 if they are deemed to be actively harmful to the project’s well-being, and
 attempts at communication and conflict resolution have failed.
 
-### Conflict of interest
+#### Conflict of interest
 
 It is expected that the BDFL and Council Members will be employed at a wide
 range of companies, universities and non-profit organizations. Because of this,
@@ -201,7 +198,7 @@ issue, but must recuse themselves from voting on the issue. If the BDFL has
 recused his/herself for a particular decision, they will appoint a substitute
 BDFL for that decision.
 
-### Private communications of the Council
+#### Private communications of the Council
 
 Unless specifically required, all Council discussions and activities will be
 public and done in collaboration and discussion with the Project Contributors
@@ -211,7 +208,7 @@ communications and decisions are needed, the Council will do its best to
 summarize those to the Community after eliding personal/private/sensitive
 information that should not be posted to the public internet.
 
-### Subcommittees
+#### Subcommittees
 
 The Council can create subcommittees that provide leadership and guidance for
 specific aspects of the project. Like the Council as a whole, subcommittees
@@ -230,7 +227,7 @@ within the team. This is different from a BDFL delegate for a specific decision
 authority to someone else in full. It’s more like what Linus Torvalds uses with his
 “lieutenants” model.
 
-### NumFOCUS Subcommittee
+#### NumFOCUS Subcommittee
 
 The Council will maintain one narrowly focused subcommittee to manage its
 interactions with NumFOCUS.
@@ -249,8 +246,7 @@ interactions with NumFOCUS.
     max). This avoids effective majorities resting on one person.
 
 
-Institutional Partners and Funding
-==================================
+## Institutional Partners and Funding
 
 The BDFL and Steering Council are the primary leadership for the project. No
 outside institution, individual or legal entity has the ability to own,
@@ -325,8 +321,7 @@ Partners, with associated benefits:
     Workshop and bi-annual Jupyter/IPython Developer Meeting.
 
 
-Changing the Governance Documents
-=================================
+## Changing the Governance Documents
 
 Changes to the governance documents are submitted via a GitHub pull
 request to The Project's governance documents GitHub repository at

--- a/intro.md
+++ b/intro.md
@@ -1,0 +1,19 @@
+# Project Jupyter Governance
+
+The purpose of this documentation is to formalize the governance process that
+the IPython/Jupyter project has used informally since its inception in 2001.
+This document clarifies how decisions are made and how the various elements
+of our community interact, including the relationship between open source
+collaborative development and work that may be funded by for-profit or non-profit entities.
+
+## Table of Contents
+
+* [Main Governance Document](governance)
+* [Current Steering Council and Institutional Partners](people)
+* [New Subproject Incubation Process](newsubprojects)
+* [Process for Authoring Jupyter Related Academic Papers](papers)
+
+## License of Governance Documents
+
+To the extent possible under law, Project Jupyter has waived all copyright and related or neighboring rights to the Project Jupyter Governance documents, in accordance with the Creative Commons [CC0 license](http://creativecommons.org/publicdomain/zero/1.0/). This work is published from the United States.  See the [LICENSE.md file](https://github.com/jupyter/governance/blob/master/LICENSE.md)
+in this repository for details.

--- a/projectlicense.md
+++ b/projectlicense.md
@@ -1,4 +1,4 @@
-# Licensing terms
+# Licensing terms for Project Jupyter code
 
 This project is licensed under the terms of the 3-Clause BSD License (also
 known as New or Revised or Modified BSD License, or the BSD-3-Clause license),


### PR DESCRIPTION
Per a recent conversation in the governance working group, this is a pull-request with the minimal amount of changes that make it possible to build our governance docs as a website. The goal of that is to make our governance procedures more discoverable and easier to read.

This PR builds the governance docs as a Jupyter Book, since that is (I think) what requires the fewest extra configuration files, but I'm happy to try a different website builder if we wish.

Note: **This PR does not change any of the governance content, it makes minor edits to make the markdown files work with Sphinx**.

The major changes that are in this PR:

* Some links to direct documents had their extensions stripped so they'd work in Sphinx
* The headers in the main governance document were mixed between ATX and Setext, so this standardizes all of them to be ATX
* Some headers jumped from `#` to `###`, this jumps instead to `##`
* A `_toc.yml` file now defines the structure of the governance book, and `_config.yml` has some simple configuration
* A `.github` workflow will auto-update the website when new changes are made to the code, and the `circleci` configuration is used to preview changes that will occur in the built documentation

✨Here's how it looks: https://14-41781271-gh.circle-artifacts.com/0/html/intro.html ✨

If merged, I believe that this would then automatically be hosted at jupyter.org/governance

(note, it's unclear to me if this PR requires a full SC vote or not. If folks think it does, then let me know and I can make this a draft PR to make it clear others shouldn't vote yet)

cc @afshin @jasongrout and @tgeorgeux who seemed interested in this in the call today