### PR TITLE
Add year indicating when each person joined the Steering Council and indicate founding members.

### DIFF
--- a/people.md
+++ b/people.md
@@ -8,23 +8,25 @@ Fernando Perez (@fperez) is the Benevolent Dictator for Life (BDFL).
 
 ## Steering Council
 
-- Brian Granger, @ellisonbg
-- Damian Avila, @damianavila
-- Fernando Perez, @fperez
-- Jason Grout, @jasongrout
-- Jessica Hamrick, @jhamrick
-- Kyle Kelley, @rgbkrk
-- Matthias Bussonnier, @carreau
-- Min Ragan-Kelley, @minrk
-- Sylvain Corlay, @sylvaincorlay
-- Thomas Kluyver, @takluyver
-- Peter Parente, @parente
-- Ana Rulvalcaba, @Ruv7
-- Carol Willing, @willingc
-- Steven Silvester, @blink1073
-- Paul Ivanov, @ivanov
-- Afshin Darian, @afshin
-- M Pacer, @mpacer
+Alphabetical by first name:
+
+- Brian Granger, @ellisonbg (Founding member, 2014)
+- Damian Avila, @damianavila (Founding member, 2014)
+- Fernando Perez, @fperez (Founding member, 2014)
+- Jason Grout, @jasongrout (2015)
+- Jessica Hamrick, @jhamrick (2015)
+- Kyle Kelley, @rgbkrk (Founding member, 2014)
+- Matthias Bussonnier, @carreau (Founding member, 2014)
+- Min Ragan-Kelley, @minrk (Founding member, 2014)
+- Sylvain Corlay, @sylvaincorlay (2016)
+- Thomas Kluyver, @takluyver (Founding member, 2014)
+- Peter Parente, @parente (2016)
+- Ana Rulvalcaba, @Ruv7 (2018)
+- Carol Willing, @willingc (2017)
+- Steven Silvester, @blink1073 (2016)
+- Paul Ivanov, @ivanov (2016)
+- Afshin Darian, @afshin (2018)
+- M Pacer, @mpacer (2018)
 
 ### Retired steering council members
 


### PR DESCRIPTION
I have been having some fun doing work around the written and verbal history of the project. I found that the record of the early Jupyter Steering Council was spread across a number of different sources. Here is a rough list of the sources I consulted for this PR:

* Fernando's talk announcing Jupyter at SciPy 2014 listed the "existing IPython Dev team" as the "Who" of Jupyter (https://speakerdeck.com/fperez/project-jupyter?slide=9).
* But the explicit list of Steering Council members didn't show up in this repo until Sept 2015 in this PR (https://github.com/jupyter/governance/pull/5).
* The hidden history can be found on our private Steering Council Google Group to which current SC members have access. Because it is private, I wanted to post something public with the relevant information. This PR is meant to capture the dates of people joining the SC that are implicit in the nomination process we ran in the Google Group over time.
* Interestingly, from the founding of Jupyter in July 2014, until January 2015, we didn't have a clear distinction between "Core Dev" and "Steering Council member." Fernando proposed that distinction in a post to the Steering Council list in Jan. 2015:

> It may be useful to have a distinction between:
>
> 1) core devs on specific projects (i.e. members of a github team with write permissions on one or more repo) vs 
> 2) membership in the Steering Council.
> I would like to be relatively liberal with #1 to encourage the growth of our community, and 'graduate' people to #2 only after some time.
