### PR TITLE
language about voting phases and a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,4 +30,4 @@ The discussion phase is meant to gather input and multiple perspectives from the
 Make sure that the community has had an opportunity to weigh in on
 the change **before calling a vote**. A good rule of thumb is to ask several steering council
 members if they believe that it is time for a vote, and to let at least one person review
-the pull request for structural quality and type-os.
+the pull request for structural quality and typos.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+Thanks for participating in Jupyter governance ✨
+Below are a few guidelines for making your proposed change as efficient and productive
+as possible.
+
+## Questions to answer ❓
+
+Please answer the following questions along with your proposed change:
+
+**Background or context to help other understand the change.**
+
+**A brief summary of the change.**
+
+**What is the reason for this change?**
+
+**Alternatives to making this change and other considerations.**
+
+
+## The process ❗
+
+The process for changing the governance pages is as follows:
+
+* Open a pull request **in draft state**. This triggers a discussion and iteration phase
+  for your proposed changes.
+* When you believe enough discussion has happened,
+  **move the pull request to an active state**. This triggers a vote.
+* During the voting phase, no substantive changes may be made to the pull request.
+* The Steering Council will vote, and at the end of voting the pull request is merged or closed.
+
+The discussion phase is meant to gather input and multiple perspectives from the community.
+Make sure that the community has had an opportunity to weigh in on
+the change **before calling a vote**. A good rule of thumb is to ask several steering council
+members if they believe that it is time for a vote, and to let at least one person review
+the pull request for structural quality and type-os.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ as possible.
 
 Please answer the following questions along with your proposed change:
 
-**Background or context to help other understand the change.**
+**Background or context to help others understand the change.**
 
 **A brief summary of the change.**
 

--- a/governance.md
+++ b/governance.md
@@ -326,7 +326,7 @@ Partners, with associated benefits:
 Changes to the governance documents are submitted via a GitHub pull
 request to The Project's governance documents GitHub repository at
 [https://github.com/jupyter/governance](https://github.com/jupyter/governance).
-There are two phases to the voting process:
+There are two phases to the process:
 
 **The discussion phase** begins when the person first opens a pull-request. During
 this time, *the pull-request must be in a draft state*.

--- a/governance.md
+++ b/governance.md
@@ -339,9 +339,7 @@ iteration has occurred. This is triggered by moving the pull request from the
 
 **The voting phase** begins when the PR enters an active state. The proposed changes
 in the pull request are frozen, and may not be substantively modified after voting
-has begun. If the author (or a steering council member) wishes to substantively change
-the proposed changes, they should close the pull request and re-start the process
-with a new pull request. During the voting phase, the Steering Council
+has begun. During the voting phase, the Steering Council
 votes on whether the changes are ratified and the pull request merged (accepting the proposed changes) or
 that the pull request be closed without merging (rejecting the proposed changes).
 

--- a/governance.md
+++ b/governance.md
@@ -328,20 +328,21 @@ request to The Project's governance documents GitHub repository at
 [https://github.com/jupyter/governance](https://github.com/jupyter/governance).
 There are two phases to the process:
 
-**The discussion phase** begins when the person first opens a pull-request. During
-this time, *the pull-request must be in a draft state*.
-The pull request is refined in response to public comment and
-review, with the goal being consensus in the community.
+**The discussion phase** begins when the person first opens a pull-request.
+During this time, *the pull-request must be in a draft state*. The pull
+request is refined in response to public comment and review, with the goal
+being consensus in the community.
 
-The pull request author may *call a vote* when they believe enough feedback and
-iteration has occurred. This is triggered by moving the pull request from the
-*draft state* to an *active state*. This triggers the voting phase.
+The pull request author may *call a vote* when they believe enough feedback
+and iteration has occurred. This is triggered by moving the pull request from
+the *draft state* to an *active state*. This triggers the voting phase.
 
-**The voting phase** begins when the PR enters an active state. The proposed changes
-in the pull request are frozen, and may not be substantively modified after voting
-has begun. During the voting phase, the Steering Council
-votes on whether the changes are ratified and the pull request merged (accepting the proposed changes) or
-that the pull request be closed without merging (rejecting the proposed changes).
+**The voting phase** begins when the PR enters an active state. The proposed
+changes in the pull request are frozen, and may not be substantively modified
+after voting has begun. During the voting phase, the Steering Council votes on
+whether the changes are ratified and the pull request merged (accepting the
+proposed changes) or that the pull request be closed without merging
+(rejecting the proposed changes).
 
 All votes are limited in time to 4 weeks after the voting phase begins. At the end of 4
 weeks, the proposal passes if 2/3 of the votes are in favor (fractions of a

--- a/governance.md
+++ b/governance.md
@@ -326,15 +326,26 @@ Partners, with associated benefits:
 Changes to the governance documents are submitted via a GitHub pull
 request to The Project's governance documents GitHub repository at
 [https://github.com/jupyter/governance](https://github.com/jupyter/governance).
-The pull request is then refined in response to public comment and
-review, with the goal being consensus in the community.  After this
-open period, a Steering Council Member proposes to the Steering
-Council that the changes be ratified and the pull request merged
-(accepting the proposed changes) or proposes that the pull request be
-closed without merging (rejecting the proposed changes).  The Member
-should state the final commit hash in the pull request being proposed
-for acceptance or rejection and briefly summarize the pull request. All votes
-are limited in time to 4 weeks after the vote is initiated. At the end of 4
+There are two phases to the voting process:
+
+**The discussion phase** begins when the person first opens a pull-request. During
+this time, *the pull-request must be in a draft state*.
+The pull request is refined in response to public comment and
+review, with the goal being consensus in the community.
+
+The pull request author may *call a vote* when they believe enough feedback and
+iteration has occurred. This is triggered by moving the pull request from the
+*draft state* to an *active state*. This triggers the voting phase.
+
+**The voting phase** begins when the PR enters an active state. The proposed changes
+in the pull request are frozen, and may not be substantively modified after voting
+has begun. If the author (or a steering council member) wishes to substantively change
+the proposed changes, they should close the pull request and re-start the process
+with a new pull request. During the voting phase, the Steering Council
+votes on whether the changes are ratified and the pull request merged (accepting the proposed changes) or
+that the pull request be closed without merging (rejecting the proposed changes).
+
+All votes are limited in time to 4 weeks after the voting phase begins. At the end of 4
 weeks, the proposal passes if 2/3 of the votes are in favor (fractions of a
 vote rounded up to the nearest integer); otherwise the proposal is rejected and
 the PR is closed. Prior to the four-week limit, if at least 80% of the Steering Council


### PR DESCRIPTION
## Background or context to help other understand the change.

In [a recent proposed change](https://github.com/jupyter/governance/pull/77), an issue arose where discussion and edits to the PR happened **after** some people had already voted. This brought up two challenges:

* It was unclear whether these notes should be nullified
* It was unclear to newcomers to the discussion [what they were voting on](https://github.com/jupyter/governance/pull/77#issuecomment-628170461).

This PR tries to improve upon both of these issues with a slight modification to the voting process. It follows two main principles:

* When people vote, it should be clear what they’re voting on, and the content of the proposed change shouldn’t be changed after they vote.
* When people haven’t been closely following a discussion, they should have quick access to the current state of conversation, and more importantly to the current thing they’re voting on.

## A brief summary of the change

This proposal adds a **discussion phase** to the voting process. During the discussion phase, the PR is in a *draft state* and feedback, iteration, and edits are encouraged.
The PR author can call a vote at any point, at which point the PR leaves "draft" phase and enters the "active" state. At this point, no edits are allowed to the PR, and input from the SC is encouraged to be in the form of voting rather than lengthy discussion.

This proposal also adds a pull-request template with language to try and encourage positive and productive voting.

## What is the reason for this change?

The aim is to make it clearer what SC members are voting on when a vote is called, and to increase the efficiency of the voting process.

## Alternatives to making this change and other considerations.

We could continue in our current voting procedure, which isn't terribly broken, but does result in confusion like the link I shared above. We could also adopt a more technically-restrictive solution, like requiring that PR authors include a commit hash with the top-level comment, but I worry that this is complex enough that it won't be followed (in fact, it has not been followed in recent PRs to the repo). This PR uses GitHub's interface to trigger a vote, which I think is a bit more natural and low-barrier to remember.


**Note**: Even though this PR is not yet merged, I'd like to follow the proposed process for this PR as much as possible. I'll open the PR in a draft state, and I welcome feedback, comments, edits, etc.

cc @afshin @jasongrout @tgeorgeux and @sharanf who were in earlier discussions about this

### Votes
- @afshin
  - [x] YES
  - [ ] NO
- @blink1073
  - [x] YES
  - [ ] NO
- @Carreau
  - [x] YES
  - [ ] NO
- @damianavila
  - [x] YES
  - [ ] NO
- @ellisonbg
  - [ ] YES
  - [ ] NO
- @fperez
  - [X] YES
  - [ ] NO
- @ivanov
  - [x] YES
  - [ ] NO
- @jasongrout
  - [x] YES
  - [ ] NO
- @jhamrick
  - [x] YES
  - [ ] NO
- @minrk
  - [x] YES
  - [ ] NO
- @mpacer
  - [x] YES
  - [ ] NO
- @parente
  - [x] YES
  - [ ] NO
- @rgbkrk
  - [x] YES
  - [ ] NO
- @Ruv7
  - [ ] YES
  - [ ] NO
- @SylvainCorlay
  - [x] YES
  - [ ] NO
- @takluyver
  - [ ] YES
  - [ ] NO
- @willingc
  - [x] YES
  - [ ] NO