### PR TITLE
Allow orgs to adopt repos without JEPs

### DIFF
--- a/newsubprojects.md
+++ b/newsubprojects.md
@@ -81,13 +81,16 @@ software in other public venues.
 
 When a Subproject is incorporated, it becomes an officially supported and maintained part
 of Project Jupyter and is moved to one of the GitHub organizations noted at the top of
-this document
+this document.
 
 
 ### Proposal for incorporation
 
-For an existing external Subproject to be incorporated into one of the main Jupyter organizations,
-the following proposal process will be used:
+If concensus for adoption within a given Jupyter organization's team is straightforward and the above criteria are met,
+a project may be adopted immediately.
+Such consensus may be established by creating an Issue on the given organization's `team-compass` repository.
+If more discussion is needed,
+the following more formal proposal process will be used:
 
 1. The Subproject team should submit a pull request against the
    [jupyter/enhancement-proposals](https://github.com/jupyter/enhancement-proposals) repository
@@ -125,7 +128,7 @@ The possible recommendations of the Steering Council will be:
 When an existing external Subproject is incorporated as a new official Subproject, the following
 steps will be taken:
 
-1. The repository will be transfered over to one of the main Jupyter GitHub organizations.
+1. The repository will be transferred over to one of the main Jupyter GitHub organizations.
 2. A GitHub team will be created for the Subproject, with the Subproject team having
    read/write permissions on the Subproject repository.
 3. The team will send an email to the main Jupyter list with an announcement about the new

--- a/newsubprojects.md
+++ b/newsubprojects.md
@@ -86,7 +86,7 @@ this document.
 
 ### Proposal for incorporation
 
-If concensus for adoption within a given Jupyter organization's team is straightforward and the above criteria are met,
+If consensus for adoption within a given Jupyter organization's team is straightforward and the above criteria are met,
 a project may be adopted immediately.
 Such consensus may be established by creating an Issue on the given organization's `team-compass` repository.
 If more discussion is needed,


### PR DESCRIPTION
It has been our practice to make most incorporation decisions at the org-level, rather than raising every repo adoption to the SC as a JEP, which this document suggests is required. This PR updates the text to make it clear that orgs can make their own decisions in many cases, and only fallback on the JEP process when a decision might be more complicated / need broader input.

Examples can include:

- Spawners / Authenticators in JupyterHub
- Extensions in JupyterLab
- Utilities created on personal repos, already adopted in orgs for better maintenance/governance


## Questions to answer

Please answer the following questions along with your proposed change:

**Background or context to help others understand the change.**

There are many cases where we have adopted repos into orgs without going through JEPs.
These are usually simple cases where consensus is established within the given team (jupyterhub, jupyterlab, etc.), without raising the issue to the level of the SC.

Examples include:

- [pytest-check-links](https://github.com/jupyterlab/team-compass/issues/46)
- [batchspawner](https://github.com/jupyterhub/batchspawner)

several others on jupyterhub, probably more on jupyterlab as well

**A brief summary of the change.**

Note that simple cases of repo adoption can be handled within github orgs and without JEPs, reflecting existing practice.

Effectively, this makes adoption more equivalent to new-repo creation, where there is an exception for direct creation of new repos by team members without JEPs.

**What is the reason for this change?**

We already adopt packages without this process when a decision is simple and clear within a given org. This updates the process docs to reflect the process in practice.

**Alternatives to making this change and other considerations.**

Actually enforce that the adoption of all repos to go through JEPs and review by SC, as the documentation states should be the case. I think we shouldn't do that, and should be explict about our trust in teams to make their own decisions in most cases, as we are already doing in practice.