### PR TITLE
Adds distinguished contributor section to our rendered docs

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -1,6 +1,7 @@
 file: intro
 sections:
 - file: governance
+- file: distinguished_contributors
 - file: conduct/code_of_conduct
   sections:
   - file: conduct/enforcement


### PR DESCRIPTION
## Explanation

This just adds the new distinguished contributors doc to the rendered governance documents.

Right now it is not listed at https://jupyter.org/governance/intro.html


## The process ❗

*Since this is merely updating our rendering, not any substantive change to the content, I think it does not need a full vote.*

