### PR TITLE
Replace myself with William Stein as part of the TM committee

### DIFF
--- a/people.md
+++ b/people.md
@@ -48,7 +48,7 @@ Alphabetical by first name:
 - Min Ragan-Kelley, @minrk
 - Paul Ivanov, @ivanov
 - Tim Geaorge, @tgeorgeux
-- Matthias Bussonnier, @carreau
+- William Stein, @williamstein
 
 ## Institutional Partners
 


### PR DESCRIPTION
See https://discourse.jupyter.org/t/looking-for-replacement-for-trademark-committee/6009/13
for other candidates, and timeline.

A Condorcet vote of the steering council had William as a winner.

Here are the results of the votes for transparency.

Results (raw past from the Condorcet voting website)

1. William Stein  (Condorcet winner: wins contests with all other choices)
2. Russ Pekrul  loses to William Stein by 8–0
3. Derek Mort  loses to William Stein by 8–0, loses to Russ Pekrul by 3–1
4. Tom Ballinger  loses to William Stein by 8–0, loses to Derek Mort by 2–1
5. Yusuf Suleiman  loses to William Stein by 7–1, loses to Tom Ballinger by 3–1

Notes that it is not given that member of the TM committee are elected
and the steering council can nominate them. Though if election there are
the process should maybe be refined in particular
 - Timeline for candidatures,
 - Timeline for vote
 - Better way to have results public and verifiable.

In particular people on the SC list have multiple emails registered;
Which could lead to issue if sending voting links to all member of the
SC mailing list.

I will also add William to the TM mailing list, and the find a way to
remove myself.

Thanks.
