### PR TITLE
reflect registered trademark status, closes #42

### DIFF
--- a/trademarks.md
+++ b/trademarks.md
@@ -27,7 +27,7 @@ of which Project Jupyter is a part.
 
 The Jupyter logos (in several variants) are trademarks of NumFOCUS as well.
 
-Registration of the trademarks is pending.
+The Jupyter Trademark is registered with the U.S. Patent & Trademark Office.
 
 Derivative word marks referring to Jupyter projects or events,
 such as "JupyterDays," "JupyterLab," "JupyterHub,"


### PR DESCRIPTION
Jupyter trademark was registered in 2017. 

See also https://github.com/jupyter/jupyter.github.io/issues/250
