### PR TITLE
Clarify that images/videos of Jupyter applications can sometimes be used without permission

### DIFF
--- a/trademarks.md
+++ b/trademarks.md
@@ -85,8 +85,8 @@ and does not imply a sponsorship relationship with the trademark holder.
 As such, stating accurately that software or a service integrates with Jupyter software,
 that it uses Jupyter software, that it is compatible with Jupyter software,
 or that it contains Jupyter software, is always allowed.
-In those cases, you may use the word "Jupyter" or the unaltered logos to indicate this,
-without our prior approval.
+In those cases, you may use the word "Jupyter", unaltered Jupyter logos, or images or videos
+of Jupyter applications to indicate this, without our prior approval.
 This is true both for non-commercial and commercial uses.
 
 This clause overrides other clauses of this policy.


### PR DESCRIPTION

## Questions to answer ❓

Please answer the following questions along with your proposed change:

**Background or context to help others understand the change.**

We've had several inquiries to the trademarks committee about using screenshots or videos of Jupyter applications. This helps clarify when approval is not necessary to use images or videos of Jupyter applications.

**A brief summary of the change.**

Add that you may use images or videos of Jupyter applications also where you may use logos or the word Jupyter without permission.

**What is the reason for this change?**

**Alternatives to making this change and other considerations.**

This is a simpler alternative to https://github.com/jupyter/governance/pull/85

## The process ❗

The process for changing the governance pages is as follows:

- [x] Open a pull request **in draft state**. This triggers a discussion and iteration phase
  for your proposed changes.
- [x]  When you believe enough discussion has happened,
  **move the pull request to an active state**. This triggers a vote.
- [x] During the voting phase, no substantive changes may be made to the pull request.
- [ ] The Steering Council will vote, and at the end of voting the pull request is merged or closed.

The discussion phase is meant to gather input and multiple perspectives from the community.
Make sure that the community has had an opportunity to weigh in on
the change **before calling a vote**. A good rule of thumb is to ask several steering council
members if they believe that it is time for a vote, and to let at least one person review
the pull request for structural quality and typos.
