### PR TITLE
Add Project Jupyter organizations to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The following organizations on GitHub contain Project Jupyter repos:
 - [jupyter-xeus](https://github.com/jupyter-xeus) See [JEP 44](https://github.com/jupyter/enhancement-proposals/tree/master/44-xeus-incorporation)
 - [voila-dashboards](https://github.com/voila-dashboards) See [JEP 42](https://github.com/jupyter/enhancement-proposals/tree/master/42-voila-incorporation)
 - [binder-examples](https://github.com/binder-examples)
+- [jupyter-resources](https://github.com/jupyter-resources)
 
 ## Infrastructure for this repository
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ The governance documents are best-viewed at https://jupyter.org/governance
 
 See [the governance introduction](intro.md) for license information.
 
+## Jupyter organizations
+
+The following organizations on GitHub contain Project Jupyter repos:
+
+- [jupyter](https://github.com/jupyter)
+- [ipython](https://github.com/ipython)
+- [jupyterhub](https://github.com/jupyterhub)
+- [jupyterlab](https://github.com/jupyterlab)
+- [jupyter-widgets](https://github.com/jupyter-widgets)
+- [jupyter-server](https://github.com/jupyter-server)
+
 ## Infrastructure for this repository
 
 The content in this repository is hosted online with `github-pages`, and the HTML

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The following organizations on GitHub contain Project Jupyter repos:
 - [jupyterlab](https://github.com/jupyterlab)
 - [jupyter-widgets](https://github.com/jupyter-widgets)
 - [jupyter-server](https://github.com/jupyter-server)
+- [jupyter-xeus](https://github.com/jupyter-xeus)
 
 ## Infrastructure for this repository
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ The following organizations on GitHub contain Project Jupyter repos:
 - [jupyterlab](https://github.com/jupyterlab)
 - [jupyter-widgets](https://github.com/jupyter-widgets)
 - [jupyter-server](https://github.com/jupyter-server)
-- [jupyter-xeus](https://github.com/jupyter-xeus)
+- [jupyter-xeus](https://github.com/jupyter-xeus) See [JEP 44](https://github.com/jupyter/enhancement-proposals/tree/master/44-xeus-incorporation)
+- [voila-dashboards](https://github.com/voila-dashboards) See [JEP 42](https://github.com/jupyter/enhancement-proposals/tree/master/42-voila-incorporation)
+- [binder-examples](https://github.com/binder-examples)
 
 ## Infrastructure for this repository
 


### PR DESCRIPTION
As we've grown, projects have split off into new orgs. I couldn't find a list of all the current GitHub orgs that contain Project Jupyter repos. I'm adding a list here, but I'm not sure if I am missing any orgs. 

Once we merge this, it would be helpful to have this list added somewhere in the website.

I'm tagging folks that have been involved in the Governance meetings as reviewers since I'm assuming that you already have this list. All members of this repo should feel free to review as well.