### PR TITLE
Adding new pages to TOC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,11 @@
+# Build the book and upload it to GitHub Artifacts for inspection in a PR
 name: build
 
 # Run on every pull request
 on:
-  push:
-    branches: master
   pull_request:
     branches: '*'
 
-# This job installs dependencies, build the book, and uploads the built artifact
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,4 @@
+# Deploy the live documentation to our GitHub Pages site
 name: deploy
 
 # Only run this when the master branch changes
@@ -10,6 +11,11 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+
+    # So that we can write to `gh-pages`
+    permissions:
+      contents: write
+
     steps:
     - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ files are built with [jupyter-book](https://jupyterbook.org). To build and previ
 these documents locally, install the latest version of Jupyter Book with:
 
 ```
-pip install -U git+https://github.com/executablebooks/jupyter-book.git
+pip install -U jupyter-book
 ```
 
 and build the book with:

--- a/_toc.yml
+++ b/_toc.yml
@@ -2,6 +2,9 @@ format: jb-article
 root: intro
 sections:
 - file: governance
+  sections:
+  - file: decision_making
+  - file: bootstrapping_decision_making
 - file: communitybuildingcommittee
 - file: distinguished_contributors
 - file: conduct/code_of_conduct
@@ -12,6 +15,9 @@ sections:
   - file: conduct/reporting_online
   - file: CodeofConductJupyterDay
   - file: CodeofConductJupyterDayOrganizer
+- file: software_subprojects
+  sections:
+  - file: list_of_subprojects
 - file: people
 - file: newsubprojects
 - file: papers


### PR DESCRIPTION
We recently added some new pages to the governance docs. This adds them to the Table of Contents, and adds `write` permissions to our deploy action so that the website will update and show the new pages.