### PR TITLE
Refactor and adding labels for readability

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -1,25 +1,37 @@
-format: jb-article
+format: jb-book
 root: intro
-sections:
-- file: governance
-  sections:
+parts:
+- caption: Code of Conduct
+  chapters:
+  - file: conduct/code_of_conduct
+    sections:
+    - file: conduct/enforcement
+    - file: conduct/reporting_online
+
+  - file: CodeofConductJupyterDay
+    sections:
+    - file: CodeofConductJupyterDayOrganizer
+    - file: conduct/reporting_events
+  - file: conduct/faq
+
+- caption: Governance
+  chapters:
+  - file: governance
   - file: decision_making
   - file: bootstrapping_decision_making
-- file: communitybuildingcommittee
-- file: distinguished_contributors
-- file: conduct/code_of_conduct
-  sections:
-  - file: conduct/enforcement
-  - file: conduct/faq
-  - file: conduct/reporting_events
-  - file: conduct/reporting_online
-  - file: CodeofConductJupyterDay
-  - file: CodeofConductJupyterDayOrganizer
-- file: software_subprojects
-  sections:
-  - file: list_of_subprojects
-- file: people
-- file: newsubprojects
-- file: papers
-- file: trademarks
-- file: projectlicense
+
+- caption: Organizational Structure
+  chapters:
+  - file: people
+  - file: communitybuildingcommittee 
+  - file: software_subprojects
+    sections:
+    - file: list_of_subprojects
+    - file: newsubprojects
+  - file: distinguished_contributors
+
+- caption: Organizational Policy
+  chapters:
+  - file: papers
+  - file: trademarks
+  - file: projectlicense

--- a/communitybuildingcommittee.md
+++ b/communitybuildingcommittee.md
@@ -1,4 +1,4 @@
-# Jupyter Community Building Committee
+# Community Building Committee
 
 The Jupyter Community Building Committee acts on behalf of the Project Jupyter
 Steering Council with the objective of growing, building, and connecting the

--- a/conduct/enforcement.md
+++ b/conduct/enforcement.md
@@ -1,4 +1,4 @@
-# Jupyter Code of Conduct - Enforcement Manual
+# Enforcement Manual
 
 This is the enforcement manual followed by Jupyter's Code of Conduct Committee.
 It's used when we respond to an incident to make sure we are consistent and

--- a/conduct/faq.md
+++ b/conduct/faq.md
@@ -1,4 +1,4 @@
-# Project Jupyter Code of Conduct - Frequently Asked Questions
+# Frequently Asked Questions
 
 This FAQ attempts to address common questions and concerns around the Jupyter
 community's Code of Conduct. If you still have questions after reading it,

--- a/conduct/reporting_events.md
+++ b/conduct/reporting_events.md
@@ -1,4 +1,4 @@
-# Project Jupyter Code of Conduct - Reporting Guide - Jupyter Events
+# Reporting Guide - Jupyter Events
 
 You can make a personal report by:
 

--- a/conduct/reporting_online.md
+++ b/conduct/reporting_online.md
@@ -1,4 +1,4 @@
-# Project Jupyter Code of Conduct - Reporting Guide - Online Community
+# Reporting Guide - Online Community
 
 If you believe someone is violating the code of conduct we ask that you report
 it to Project Jupyter by emailing

--- a/distinguished_contributors.md
+++ b/distinguished_contributors.md
@@ -1,16 +1,23 @@
-# Jupyter Distinguished Contributors
+# Distinguished Contributors
+
 ## Purpose
 This document describes the Distinguished Contributors body of the Jupyter Governance Model. Membership in the Distinguished Contributors is meant to recognize the work of community members that have gone above-and-beyond in their work on the project. It is not meant as a means of conveying power or responsibility. A public record of each Distinguished Contributor’s current biography and achievements will be maintained by the members themselves and will be displayed on the Jupyter website.
+
 ## Rights of Distinguished Contributors
 Distinguished Contributors have the right to elect new Distinguished Contributors. We recognize the knowledge and experience that Distinguished Contributors bring to the project. From time to time, the Board of Directors and Software Steering Council may poll the group of Distinguished Contributors for their insights.
+
 ## Distinguished Contributor membership
+
 ### Criteria for Nominating New Distinguished Contributors
 To be considered for nomination as a Distinguished Contributor a Project Contributor must have produced contributions to Jupyter itself that are substantial in quality and quantity, and sustained over at least two years. When considering potential Members, the existing Distinguished Contributors will look at nominees with a comprehensive view of their contributions. This will include but is not limited to code, code review, infrastructure work, mailing list and chat participation, community help/building, education and outreach, fundraising, branding, marketing, inclusion and diversity, UX design and research, etc. We are deliberately not setting arbitrary quantitative metrics (like “100 commits in this repo”) to avoid encouraging behavior that plays to the metrics rather than the project’s overall well-being. 
+
 ### Term length
 Membership in the Distinguished Contributors body is a lifetime appointment. 
+
 ### Selecting Distinguished Contributors Members
 Distinguished Contributors are added to this body on an annual basis, through a voting process carried out by the pre-existing body of Distinguished Contributors. The number of candidates chosen each year will be limited to 10 new members. Nominations for election can be submitted by any Distinguished Contributor to be reviewed by a committee of peer reviewers chosen from the Distinguished Contributors. This committee is responsible for managing the private voting process and reviewing nominees to ensure that they meet the minimum criteria for Distinguished Contributor status. After nominees are finalized, the Distinguished Contributors will vote in a ranked preference process. 
 
 Each newly inducted member will be awarded a nominal purse of $500 per awardee, subject to budgetary constraints, in recognition for service to the community.
+
 ### Bootstrapping the Distinguished Contributors
 The inaugural members of the Distinguished Contributors will be the members of the original Jupyter Steering Council. There will be no monetary award for these bootstrap year inductions. Within the first 3 months of its existence, the DCs will run a special election to address the backlog of potential DCs. This special election will be limited to 20 additional members.

--- a/governance.md
+++ b/governance.md
@@ -1,4 +1,4 @@
-# Main Governance Document
+# Governance of Project Jupyter
 
 The official version of this document, along with a list of
 individuals and institutions in the roles defined in the governance

--- a/newsubprojects.md
+++ b/newsubprojects.md
@@ -1,20 +1,9 @@
 # New Subproject Process
 
-Project Jupyter is organized as a set of Subprojects that are each a GitHub
-repository with a development team that follows the Jupyter governance, license
-and contribution model. Officially supported and maintained Subprojects are
-hosted under the following GitHub organizations:
-
-* [github.com/jupyter](https://github.com/jupyter)
-* [github.com/jupyterhub](https://github.com/jupyterhub)
-* [github.com/jupyterlab](https://github.com/jupyterlab)
-* [github.com/jupyter-resources](https://github.com/jupyter-resources)
-* [github.com/jupyter-widgets](https://github.com/jupyter-widgets)
-* [github.com/ipython](https://github.com/ipython)
-
 This document describes the process by which new Subprojects are created in or
-moved to these organizations from other locations. There are two ways that new
-Subprojects are created:
+moved to these organizations from other locations. For a list of current sub-projects in the Jupyter Community, see [the list of sub-projects](list_of_subprojects.md).
+
+There are two ways that new Subprojects are created:
 
 1. [Direct Subproject creation](#direct-subproject-creation)
     * e.g., when contributors to an existing Subproject decide to create a new

--- a/software_subprojects.md
+++ b/software_subprojects.md
@@ -1,4 +1,4 @@
-# Software Subprojects of Project Jupyter
+# Software Subprojects
 
 Software design and development in Project Jupyter is organized into a set of Software Subprojects. These software Subprojects often map onto GitHub repositories/organizations, but that is not strictly required. The lifecycle of Software Subprojects is [described in detail here](newsubprojects.md).
 


### PR DESCRIPTION
This PR does not change any of our governance processes, it is a housekeeping PR with the following goals:

- Make it easier to parse the Table of Contents
- Naturally group sections together
- Remove information that is now incorrect after merging previous PRs

It does a few things:

- Add some high-level caption headers so that we separate out the major sections of this document
- Nest some sections underneath one another so that we reduce the total top-level sections people must parse
- Removes an outdated "list of jupyter subprojects" and now links to our new dedicated page
- Removes some extra redundant wording in titles to make the TOC easier to read

I think that the easiest way to review this PR would be to look at the new Table of Contents structure. Here it is collapsed:

![image](https://user-images.githubusercontent.com/1839645/133511238-67cae539-60d5-4e45-bab9-80621714c511.png)

and expanded:

![image](https://user-images.githubusercontent.com/1839645/133511257-889dbdb1-e423-4b81-baf3-2789f8f1a7e1.png)

compare this to the current live ToC:

![image](https://user-images.githubusercontent.com/1839645/133511634-d3240455-d946-49e7-9488-3c3e8f591f4f.png)
