### PR TITLE
Change the designation of Jupyter Accessibility to a Subproject

### DIFF
--- a/list_of_standing_committees_and_working_groups.md
+++ b/list_of_standing_committees_and_working_groups.md
@@ -25,9 +25,3 @@ Charter Summary: License, protect, and promote the trademarks and visual and tex
 ### Community Building and Events
 
 [Charter](communitybuildingcommittee.md) Summary: Grow, build, and connect the global Jupyter community of users and contributors.
-
-
-### Accessibility
-
-Charter Summary: Build cross-project community, resources, and tools to support the inclusion of people with disabilities in Jupyter applications and development.
-

--- a/list_of_subprojects.md
+++ b/list_of_subprojects.md
@@ -7,7 +7,7 @@ At the highest level, any Github repository under any official Jupyter GitHub or
 The following Jupyter Subprojects have their own formal decision-making body that elects and maintains an SSC representative:
 
 - JupyterLab (https://github.com/jupyterlab/jupyterlab)
-- JupyterHub and Binder 
+- JupyterHub and Binder
   - Jupyterhub (https://github.com/jupyterhub/jupyterhub)
   - Binder (https://github.com/jupyterhub/binder)
   - BinderHub (https://github.com/jupyterhub/binderhub)
@@ -25,6 +25,7 @@ The following Jupyter Subprojects have their own formal decision-making body tha
 - Jupyter Foundations
 - Jupyter Standards
 - Jupyter Security (https://github.com/jupyter/security)
+- Jupyter Accessibility (https://github.com/jupyter/accessibility)
 
 ## Official Subprojects without SSC representation
 

--- a/software_steering_council.md
+++ b/software_steering_council.md
@@ -35,7 +35,7 @@ SSC members are leaders from Jupyter Subprojects that wish to assist the communi
 
 ### Member composition
 
-The Software Steering Council is composed of one representative from each of the Jupyter Subprojects. In addition, the SSC will contain members from certain Working Groups and Standing Committees whose scope has important impact on SSC activities, such as Diversity and Inclusion, Accessibility, and Internationalization.
+The Software Steering Council is composed of one representative from each of the Jupyter Subprojects. In addition, the SSC will contain members from certain Working Groups and Standing Committees whose scope has important impact on SSC activities, such as Diversity and Inclusion, and Internationalization.
 
 ### Term length
 


### PR DESCRIPTION
This is a targeted PR that is the result of a vote; I would propose moving quickly into the voting phase.

## Questions to answer ❓

Please answer the following questions along with your proposed change:

**Background or context to help others understand the change.**
The Jupyter Accessibility group discussed different options for whether to be a Working Group, Standing Committee, or a Subproject. In particular, Tania wrote [an issue on this subject](https://github.com/jupyter/governance/issues/124) which led to some good discussion both during the governance calls and during the accessibility calls.

**A brief summary of the change.**
This PR changes the designation of Jupyter Accessibility from a Working Group to a Subproject instead.

**What is the reason for this change?**
The group held a vote and chose the option of changing their designation to a Jupyter Subproject: https://github.com/jupyter/accessibility/issues/81

**Alternatives to making this change and other considerations.**
cf. [this write up mentioned above that considered alternatives](https://github.com/jupyter/governance/issues/124)

## The process ❗

The process for changing the governance pages is as follows:

* Open a pull request **in draft state**. This triggers a discussion and iteration phase for your proposed changes.
* When you believe enough discussion has happened, **move the pull request to an active state**. This triggers a vote.
* During the voting phase, no substantive changes may be made to the pull request.
* The Steering Council will vote, and at the end of voting the pull request is merged or closed.

The discussion phase is meant to gather input and multiple perspectives from the community.
Make sure that the community has had an opportunity to weigh in on the change **before calling a vote**.
A good rule of thumb is to ask several steering council members if they believe that it is time for a vote, and to let at least one person review the pull request for structural quality and typos.

**CC:** @isabela-pf @trallard @fcollonval @ajbozarth @tonyfast @jupyter/steeringcouncil 

## Votes

> All votes are limited in time to 4 weeks after the voting phase begins. At the end of 4 weeks, the proposal passes if 2/3 of the votes are in favor (fractions of a vote rounded up to the nearest integer); otherwise the proposal is rejected and the PR is closed. Prior to the four-week limit, if at least 80% of the Steering Council has voted and 2/3 of the votes are in favor (fractions of a vote rounded up to the nearest integer), the proposal passes.

**The voting period for the PR is from 10 May 2022 to 7 June 2022 anywhere on 🌍**

@afshin
- [x] YES
- [ ] NO

@blink1073
- [x] YES
- [ ] NO

@Carreau
- [ ] YES
- [ ] NO

@damianavila
- [x] YES
- [ ] NO

@ellisonbg
- [x] YES
- [ ] NO

@fperez
- [x] YES
- [ ] NO

@ivanov
- [ ] YES
- [ ] NO

@jasongrout
- [x] YES
- [ ] NO

@jhamrick
- [ ] YES
- [ ] NO

@minrk
- [x] YES
- [ ] NO

@mpacer
- [ ] YES
- [ ] NO

@parente
- [ ] YES
- [ ] NO

@rgbkrk
- [ ] YES
- [ ] NO

@Ruv7
- [x] YES
- [ ] NO

@SylvainCorlay
- [ ] YES
- [ ] NO

@takluyver
- [x] YES
- [ ] NO

@willingc
- [ ] YES
- [ ] NO
