### PR TITLE
Specify SSC eligibility and make explicit that multiple Subproject representation is allowed

### DIFF
--- a/software_steering_council.md
+++ b/software_steering_council.md
@@ -19,11 +19,11 @@ The SSC is responsible for the following:
 - Owning, managing and implementing the Jupyter Attic process (https://github.com/jupyter-attic).
 - Stewarding discussions and activities beyond JEPs that involve cross-cutting concerns, standards, protocols and other architectural issues that impact the entire project.
 - Owning and managing anything related to security vulnerabilities across the project, including the Jupyter security lists, any private security repositories, etc.
-- Voting to accept Working Groups nominated by the EC to have a representative on the SSC.
+- Voting to accept Working Groups nominated by the Executive Council (EC) to have a representative on the SSC.
 
-### Shared responsibilities with the Executive Board
+### Shared responsibilities with the Executive Council
 
-The SSC and Executive Board share the responsibility for:
+The SSC and EC share the responsibility for:
 
 - Changes to the Jupyter Governance model.
 - Creation of new Jupyter Subprojects.
@@ -31,9 +31,9 @@ The SSC and Executive Board share the responsibility for:
 
 ## Membership
 
-SSC members are leaders from Jupyter Subprojects that wish to assist the community in sharing information across projects and participate in decision-making that affects many stakeholders in the Jupyter ecosystem. Membership requires active and ongoing participation in Jupyter.
+SSC members are representatives from Jupyter Subprojects that wish to assist the community in sharing information across projects and participate in decision-making that affects many stakeholders in the Jupyter ecosystem. Any Subproject council member is eligible to represent the Subproject on the SSC. While not ideal, one person may serve as the SSC representative for more than one Subproject. In this case, a representative may cast one vote for each Subproject they represent in SSC decisions.
 
-A person may not serve simultaneously on the SSC and EC.
+A person may not serve simultaneously on the SSC and the EC.
 
 The SSC may vote to remove an SSC member. A removal motion passes if two-thirds of the entire SSC votes in favor of removal. All SSC members are expected to vote without recusal, including the member in question.
 


### PR DESCRIPTION
**Background or context to help others understand the change.**

Recently we've seen some people assuming that the leader/maintainer of a Subproject should be the SSC representative. Also we've had a question about the corner case of one person representing multiple Subprojects.

cf. https://github.com/jupyterhub/team-compass/issues/544#issuecomment-1206671829

**A brief summary of the change.**

This change clarifies that any member of a Subproject council is eligible to represent the Subproject on the SSC and removes the implication that the person must be a _leader_ in the Subproject (which some may assume is the person doing releases, etc.). It also clarifies how representation works in the case where one person represents multiple Subprojects.

**The process ❗**

<details>
<summary>The process for changing the governance pages is as follows:</summary>
* Open a pull request **in draft state**. This triggers a discussion and iteration phase for your proposed changes.
* When you believe enough discussion has happened, **move the pull request to an active state**. This triggers a vote.
* During the voting phase, no substantive changes may be made to the pull request.
* The Steering Council will vote, and at the end of voting the pull request is merged or closed.

The discussion phase is meant to gather input and multiple perspectives from the community.

Make sure that the community has had an opportunity to weigh in on the change **before calling a vote**. A good rule of thumb is to ask several Steering Council members if they believe that it is time for a vote, and to let at least one person review the pull request for structural quality and typos.
</details>

## Votes

> All votes are limited in time to 4 weeks after the voting phase begins. At the end of 4 weeks, the proposal passes if 2/3 of the votes are in favor (fractions of a vote rounded up to the nearest integer); otherwise the proposal is rejected and the PR is closed. Prior to the four-week limit, if at least 80% of the Steering Council has voted and 2/3 of the votes are in favor (fractions of a vote rounded up to the nearest integer), the proposal passes.

**The voting period for the PR is from 24 July 2022 to 21 September 2022 anywhere on 🌍**

@afshin
- [x] YES
- [ ] NO

@blink1073
- [ ] YES
- [ ] NO

@Carreau
- [x] YES
- [ ] NO

@damianavila
- [x] YES
- [ ] NO

@ellisonbg
- [x] YES
- [ ] NO

@fperez
- [x] YES
- [ ] NO

@ivanov
- [ ] YES
- [ ] NO

@jasongrout
- [x] YES
- [ ] NO

@jhamrick
- [ ] YES
- [ ] NO

@minrk
- [ ] YES
- [ ] NO

@mpacer
- [ ] YES
- [ ] NO

@parente
- [ ] YES
- [ ] NO

@rgbkrk
- [ ] YES
- [ ] NO

@Ruv7
- [x] YES
- [ ] NO

@SylvainCorlay
- [ ] YES
- [ ] NO

@takluyver
- [ ] YES
- [ ] NO

@willingc
- [ ] YES
- [ ] NO

