### PR TITLE
Simplifies the template to remove boilerplate visible in the resulting PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,33 +1,115 @@
+<!-- 
 Thanks for participating in Jupyter governance ✨
 Below are a few guidelines for making your proposed change as efficient and productive
 as possible.
+-->
 
 ## Questions to answer ❓
 
-Please answer the following questions along with your proposed change:
+<!-- Please answer the following questions along with your proposed change: -->
 
-**Background or context to help others understand the change.**
+### Background or context to help others understand the change.
 
-**A brief summary of the change.**
+### A brief summary of the change.
 
-**What is the reason for this change?**
+### What is the reason for this change?
 
-**Alternatives to making this change and other considerations.**
+### Alternatives to making this change and other considerations.
 
 
-## The process ❗
+> ## The process ❗
+> 
+> The process for changing the governance pages is as follows:
+> 
+> * Open a pull request **in draft state**. This triggers a discussion and iteration phase
+>   for your proposed changes.
+> * When you believe enough discussion has happened,
+>   **move the pull request to an active state**. This triggers a vote.
+> * During the voting phase, no substantive changes may be made to the pull request.
+> * The Steering Council will vote, and at the end of voting the pull request is merged or closed.
+> 
+> The discussion phase is meant to gather input and multiple perspectives from the community.
+> Make sure that the community has had an opportunity to weigh in on
+> the change **before calling a vote**. A good rule of thumb is to ask several Steering Council
+> members if they believe that it is time for a vote, and to let at least one person review
+> the pull request for structural quality and typos.
 
-The process for changing the governance pages is as follows:
+<!--
 
-* Open a pull request **in draft state**. This triggers a discussion and iteration phase
-  for your proposed changes.
-* When you believe enough discussion has happened,
-  **move the pull request to an active state**. This triggers a vote.
-* During the voting phase, no substantive changes may be made to the pull request.
-* The Steering Council will vote, and at the end of voting the pull request is merged or closed.
+When this proposal moves to the voting stage, uncomment this section for the voting to happen. Be sure to change the voting dates listed below.
 
-The discussion phase is meant to gather input and multiple perspectives from the community.
-Make sure that the community has had an opportunity to weigh in on
-the change **before calling a vote**. A good rule of thumb is to ask several Steering Council
-members if they believe that it is time for a vote, and to let at least one person review
-the pull request for structural quality and typos.
+## Votes
+
+> All votes are limited in time to 4 weeks after the voting phase begins. At the end of 4 weeks, the proposal passes if 2/3 of the votes are in favor (fractions of a vote rounded up to the nearest integer); otherwise the proposal is rejected and the PR is closed. Prior to the four-week limit, if at least 80% of the Steering Council has voted and 2/3 of the votes are in favor (fractions of a vote rounded up to the nearest integer), the proposal passes.
+
+**The voting period for the PR is from 22 Aug 2022 to 19 Sep 2022 anywhere on earth 🌍**
+
+@afshin
+- [ ] YES
+- [ ] NO
+
+@blink1073
+- [ ] YES
+- [ ] NO
+
+@Carreau
+- [ ] YES
+- [ ] NO
+
+@damianavila
+- [ ] YES
+- [ ] NO
+
+@ellisonbg
+- [ ] YES
+- [ ] NO
+
+@fperez
+- [x] YES
+- [ ] NO
+
+@ivanov
+- [ ] YES
+- [ ] NO
+
+@jasongrout
+- [x] YES
+- [ ] NO
+
+@jhamrick
+- [ ] YES
+- [ ] NO
+
+@minrk
+- [ ] YES
+- [ ] NO
+
+@mpacer
+- [ ] YES
+- [ ] NO
+
+@parente
+- [ ] YES
+- [ ] NO
+
+@rgbkrk
+- [ ] YES
+- [ ] NO
+
+@Ruv7
+- [ ] YES
+- [ ] NO
+
+@SylvainCorlay
+- [ ] YES
+- [ ] NO
+
+@takluyver
+- [ ] YES
+- [ ] NO
+
+@willingc
+- [ ] YES
+- [ ] NO
+
+-->


### PR DESCRIPTION
This is not a governance change. As such, I don't think it needs an SC vote. This PR suggests some changes for the new PR template to make it easier for SC members to quickly read the content of governance PRs.

Right now, the actual content of the PR gets lost (to me) in the boilerplate of this template. This change:

- Comments out sections that are to the PR author
- Quotes sections that are boilerplate so it is easier to differentiate between boilerplate and content
- Adds a commented out voting section so that it is easy to move to the voting stage and call for a vote.
