### PR TITLE
Add EC to table of contents

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -38,4 +38,5 @@ parts:
 - caption: Future Governance
   chapters:
   - file: bootstrapping_decision_making
+  - file: executive_council
   - file: software_steering_council


### PR DESCRIPTION
This adds the existing Executive Council document to the table of contents. It is meant as an administrative change that does not need a vote.

