### PR TITLE
Add committee list to the future governance section

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -35,7 +35,7 @@ parts:
   - file: trademarks
   - file: projectlicense
 
-- caption: Future Governance
+- caption: Future Governance [work in progress]
   chapters:
   - file: bootstrapping_decision_making
   - file: executive_council

--- a/_toc.yml
+++ b/_toc.yml
@@ -40,3 +40,4 @@ parts:
   - file: bootstrapping_decision_making
   - file: executive_council
   - file: software_steering_council
+  - file: list_of_standing_committees_and_working_groups

--- a/executive_council.md
+++ b/executive_council.md
@@ -1,5 +1,7 @@
 # Executive Council
 
+The Executive Council is part of a new governance model for Project Jupyter and is not formed yet.
+
 ## Purpose
 
 The Executive Council (EC) is ultimately responsible for all dimensions of the Project (including, but not limited to, software, legal, financial, community, operations, inclusion and diversity, etc.). The members of the EC actively work to carry out the Project's mission in accordance with its values and to support operations through delegation to the Software Steering Council (SSC), Software Subprojects, Standing Committees, and Working Groups. These other bodies will report to the EC, and the EC is expected to support, oversee, manage, and ensure the success of operations across Jupyter.


### PR DESCRIPTION
Like #135, this is meant as a purely administrative change to (1) add the committee list to the future governance section, and (b) to clarify that the new governance sections are not yet in force. As such, I don't believe this PR needs a vote.