### PR TITLE
Add new governance overview document (no material changes)

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -1,0 +1,35 @@
+# Jupyter Governance Overview
+
+Jupyter has undergone a transition from a Benevolent Dictator For Life (BDFL) + Steering Council model of governance to a new one, based on several related bodies. This document is a brief informational overview of this new model, which is being enacted as of October 2022.
+
+_Note:_ this document provides an informational summary of multiple documents in our governance repository that were individually voted on. Any deviation of , the underlying governance documents should be considered as the source of truth, and we will update this overview as needed.
+
+Jupyter’s new governance model is anchored on two bodies that complement each other:
+
+1. The **Executive Council (EC)** is ultimately responsible for all dimensions of the Project (including, but not limited to, software, legal, financial, community, operations, inclusion and diversity, etc.). The members of the EC actively work to carry out the Project's mission in accordance with its values and to support operations through delegation to the Software Steering Council (SSC), Software Subprojects, Standing Committees, and Working Groups. These other bodies will report to the EC, and the EC is expected to support, oversee, manage, and ensure the success of operations across Jupyter. For more detail, see the [Executive Council document](executive_council.md).
+2. The Jupyter **Software Steering Council (SSC)** has jurisdiction over software-related decisions across Project Jupyter, with a primary focus on coordination across projects and decisions that have impact across many Jupyter Subprojects. It is also a mechanism for representatives of each project to share information and expertise. Technical decisions and processes where the SSC isn't explicitly involved are automatically delegated to the individual projects to manage their day-to-day activities, create new repositories in their orgs, etc., with independence and autonomy. For more details, see the [Software Steering Council document](software_steering_council.md).
+
+Additionally, the Executive Council (EC) receives input from a Community Advisory Panel. This panel advises the EC with perspectives and connections that may reach beyond the active Jupyter community. As of October 2022, this Panel has not been finalized, but one of the first orders of business of the EC will be to form this new body, in consultation with input from the community.
+
+## Other major components of the organization
+
+In addition to these three bodies, the following are other major parts of the Project related to governance.
+
+### Distinguished Contributors
+
+The Distinguished Contributors are a group of Jovyans that have gone above-and-beyond in their support of the project over the years, making substantial and sustained contributions in any area of activity (software development, governance, community engagement, events, etc.). The Jupyter community confers membership in this group as a way of recognizing their effort and saying “thank you.” For more detail, see the [Distinguished Contributors document](distinguished_contributors.md).
+
+### Standing Committees and Working Groups
+
+In addition to the software work on Jupyter that is coordinated through the Software Steering Council (SSC), much of the project’s work expands beyond software. Examples include code of conduct incident response, diversity and inclusion, operations, legal, fundraising, events, community, and marketing. Standing Committees and Working Groups carry out this non-software related work of the project by delegation from the Executive Board (EB).
+
+The primary difference between Standing Committees and Working Groups is that Standing Committees are intended to be permanent; they are only created and dissolved by a joint vote of the EB and SSC. In contrast, Working Groups can be created and dissolved by the EB acting alone.
+
+### Software Subprojects
+
+Software Subprojects in the Jupyter community are official areas of focus and effort within the Jupyter ecosystem. They often map to a single GitHub organization. Subprojects must abide by the [Jupyter Code of Conduct](code_of_conduct.md), Jupyter decision-making and governance processes (e.g. respecting the project's trademark policies), as well as commit to certain technical limitations and scope. Each subproject elects one person to serve on the Software Steering Council. For more details, see the [Software Subprojects document](software_subprojects.md).
+
+## Decision-making and voting procedures
+
+The EC, SSC, Standing Committees and Working Groups all use uniform voting procedures outlined in the [Decision-Making Guide](decision_making.md).
+


### PR DESCRIPTION
This adds an overview document describing the new governance model. It doesn't materially modify any of the approved documents.