### PR TITLE
Add toc link to EC boostrapping document

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -39,6 +39,7 @@ parts:
   chapters:
   - file: overview
   - file: bootstrapping_decision_making
+  - file: bootstrapping_executive_council
   - file: executive_council
   - file: software_steering_council
   - file: standing_committees_and_working_groups.md

--- a/bootstrapping_executive_council.md
+++ b/bootstrapping_executive_council.md
@@ -1,4 +1,4 @@
-# Creation of the Executive Council and transition to the new governance model
+# Bootstrapping Executive Council and New Governance
 
 ## Scope and overview
 


### PR DESCRIPTION

## Questions to answer ❓

<!-- Please answer the following questions along with your proposed change: -->

### Background or context to help others understand the change.

### A brief summary of the change.

This is a bookkeeping change, adding the EC bootstrapping document to the table of contents and making the title of that document more concise. I don't think it needs a vote, as it is not changing any governance content.


### What is the reason for this change?

As we go into the EC election, I thought it would be important to surface the EC bootstrapping document at the top level of the governance TOC.
