### PR TITLE
Update deploy script to use main branch instead of master branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ name: deploy
 on:
   push:
     branches:
-    - master
+    - main
 
 # This job installs dependencies, builds the book, and pushes it to `gh-pages`
 jobs:


### PR DESCRIPTION
This is an administrative change. The default branch has been updated from `master` to `main`, but the github workflow was not updated, so doc updates are not being deployed.