### PR TITLE
Fix EC mailing list link

### DIFF
--- a/executive_council.md
+++ b/executive_council.md
@@ -45,7 +45,7 @@ In these decisions, each body will [vote](decision_making.md) independently and 
 
 To contact the EC, at your preference you may:
 
-* Email the [EC mailing list](jupyter-executive-council@googlegroups.com) (this list is private but open for posting).
+* Email the [EC mailing list](mailto:jupyter-executive-council@googlegroups.com) (this list is private but open for posting).
 * Join the weekly public office hours held on [Zoom on Tuesdays at 10am Pacific](https://zoom.us/j/2264645576?pwd=c0JZTHlNdS9Sek9vdzR3aTJ4SzFTQT09).
 * Open a new issue on the [governance repository](https://github.com/jupyter/governance/issues/new).
 


### PR DESCRIPTION
This is an administrative item, fixing the link that was added in https://github.com/jupyter/governance/pull/153