### PR TITLE
Update executive_council.md

### DIFF
--- a/executive_council.md
+++ b/executive_council.md
@@ -47,7 +47,7 @@ To contact the EC, at your preference you may:
 
 * Email the [EC mailing list](mailto:jupyter-executive-council@googlegroups.com) (this list is private but open for posting).
 * Join the regular public office hours of the EC. See the [Jupyter Community Calendar](https://discourse.jupyter.org/t/jupyter-community-calendar/2485) for details.
-* Open a new issue on the [governance repository](https://github.com/jupyter/governance/issues/new).
+* Open a new issue on the [EC Team Compass](https://github.com/jupyter/executive-council-team-compass/issues/new).
 
 ## Council membership and elections
 


### PR DESCRIPTION
### A brief summary of the change.
Redirected the contact directions for the EC to include opening a new issue on the EC Team Compass instead of the governance repo.

### What is the reason for this change?
Cancelling of office hours for two weeks prompted me to double check the contact us instructions on this page. 

### Alternatives to making this change and other considerations.
We could also link to both places (EC Team Compass and Governance) if anyone can thinks that's advantageous let me know. 


