### PR TITLE
Update placement of reporting links in code of conduct 

### DIFF
--- a/conduct/code_of_conduct.md
+++ b/conduct/code_of_conduct.md
@@ -30,11 +30,7 @@ However, sometimes these informal processes may be inadequate: they fail to
 work, there is urgency or risk to someone, nobody is intervening publicly and
 you don't feel comfortable speaking in public, etc.  For these or other
 reasons, structured follow-up may be necessary and here we provide the means
-for that: we welcome reports by emailing
-[*conduct@jupyter.org*](mailto:conduct@jupyter.org) or by filling out [this
-form](https://forms.gle/gRMQc9G4hejqoqgC8). For more details please see our
-Reporting Guidelines (for [online](reporting_online) and
-[in-person](reporting_events) contexts).
+for that as described in the [Reporting](#Reporting) section.
 
 This code applies equally to founders, developers, mentors and new community
 members, in all spaces managed by Project Jupyter (including IPython). This
@@ -43,6 +39,7 @@ events, the [Discourse community forum](https://discourse.jupyter.org),
 and any other forums created by the project team. In addition,
 violations of this code outside these spaces may affect a person's ability to
 participate within them.
+
 
 ## Expected behavior
 
@@ -124,7 +121,7 @@ or other local personnel that are present.
 In situations where an individual community member acts unilaterally,
 they must inform the Code of Conduct committee as soon as possible,
 by e-mailing
-[*conduct@jupyter.org*](mailto:conduct@jupyter.org)*reporting_online*)
+[*conduct@jupyter.org*](mailto:conduct@jupyter.org)
 within 24 hours.
 
 
@@ -138,7 +135,8 @@ You can file a report by emailing
 [*conduct@jupyter.org*](mailto:conduct@jupyter.org) or by filling out
 [this form](https://forms.gle/gRMQc9G4hejqoqgC8). For more details or
 information on reporting in-person at an event, please see our Reporting
-Guidelines.
+Guidelines (for [online](reporting_online) and
+[in-person](reporting_events) contexts).
 
 The online form gives you the option to keep your report anonymous or request
 that we follow up with you directly. While we cannot follow up on an anonymous


### PR DESCRIPTION
Remove broken link, de-duplicate reporting

## Questions to answer ❓

### Background or context to help others understand the change.

I noticed that `by e-mailing
[*conduct@jupyter.org*](mailto:conduct@jupyter.org)*reporting_online*)` has what appears to be a broken link to `reporting_online` and wanted to fix this.

Then I noticed that Reporting section does not actually link to reporting guidelines, although it mentions them. Instead these guidelines were linked in the introduction.

### A brief summary of the change.

I removed the broken link and moved reporting guidelines links to reporting section, while adding a link to the reporting section in the introduction.

### What is the reason for this change?

I wanted to fix the broken link and make it easier to understand reporting options by gathering them in one place.

### Alternatives to making this change and other considerations.

Maybe the link to `reporting_online` should be restored in `Responding to inappropriate behavior` section rather than removed but after the other changes it is in the following "Reporting" section which is already linked from this section.

> ## The process ❗
> 
> The process for changing the governance pages is as follows:
> 
> * Open a pull request **in draft state**. This triggers a discussion and iteration phase
>   for your proposed changes.
> * When you believe enough discussion has happened,
>   **move the pull request to an active state**. This triggers a vote.
> * During the voting phase, no substantive changes may be made to the pull request.
> * The Executive Council and Software Steering Council will vote, and at the end of voting the pull request is merged or closed.
> 
> The discussion phase is meant to gather input and multiple perspectives from the community.
> Make sure that the community has had an opportunity to weigh in on
> the change **before calling a vote**. A good rule of thumb is to ask several Council
> members if they believe that it is time for a vote, and to let at least one person review
> the pull request for structural quality and typos.
