### PR TITLE
Fix link to enforcement procedure

### DIFF
--- a/conduct/reporting_online.md
+++ b/conduct/reporting_online.md
@@ -50,7 +50,7 @@ means we may delay an "official" response until we believe that the situation
 has ended and that everyone is physically safe.
 
 The Code of Conduct committee will then follow the
-[standard procedure][enforcement.md#Resolutions] to arrive at and
+[standard procedure](enforcement.md#Resolutions) to arrive at and
 communicate a resolution.
 
 


### PR DESCRIPTION
I believe this does not require discussion as this is just a typo fix.

Before:

![Screenshot from 2023-04-12 06-18-28](https://user-images.githubusercontent.com/5832902/231358329-0e4dfc43-cad2-4440-b271-7d201faa5070.png)

Expected after:

![Screenshot from 2023-04-12 06-22-45](https://user-images.githubusercontent.com/5832902/231358443-4eaf123e-b293-4245-a417-5374ced4afd8.png)
