### PR TITLE
Group reporting guidelines guidelines in ToC

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -24,11 +24,11 @@ parts:
     sections:
     - file: conduct/enforcement
     - file: conduct/reporting_online
+    - file: conduct/reporting_events
 
   - file: CodeofConductJupyterDay
     sections:
     - file: CodeofConductJupyterDayOrganizer
-    - file: conduct/reporting_events
   - file: conduct/faq
 
 - caption: Organizational Policy


### PR DESCRIPTION
## Questions to answer ❓

### Background or context to help others understand the change.

I was surprised to see that reporting during events was in the Jupyter Day section. I think it fits better next to the online reporting section.

The current structure was introduced in https://github.com/jupyter/governance/pull/115. @choldgraf do you have an opinion on this one?

### A brief summary of the change.

| Before | After |
|---|---|
|![Screenshot from 2023-04-12 06-29-42](https://user-images.githubusercontent.com/5832902/231359581-415d3ffc-848c-47f4-ad1e-d578d2352623.png)| ![Screenshot from 2023-04-12 06-27-12](https://user-images.githubusercontent.com/5832902/231359253-ef1bc5bd-49ca-4ca5-aa01-a90e17788d17.png) |

### What is the reason for this change?

Conceptually, there are in-person Jupyter events other than JupyterDay.

### Alternatives to making this change and other considerations.

Leave it as is, since it might be indeed of interest of JupyterDay attendees?

> ## The process ❗
> 
> The process for changing the governance pages is as follows:
> 
> * Open a pull request **in draft state**. This triggers a discussion and iteration phase
>   for your proposed changes.
> * When you believe enough discussion has happened,
>   **move the pull request to an active state**. This triggers a vote.
> * During the voting phase, no substantive changes may be made to the pull request.
> * The Executive Council and Software Steering Council will vote, and at the end of voting the pull request is merged or closed.
> 
> The discussion phase is meant to gather input and multiple perspectives from the community.
> Make sure that the community has had an opportunity to weigh in on
> the change **before calling a vote**. A good rule of thumb is to ask several Council
> members if they believe that it is time for a vote, and to let at least one person review
> the pull request for structural quality and typos.
