### PR TITLE
Point to EC team compass from governance docs

### DIFF
--- a/executive_council.md
+++ b/executive_council.md
@@ -41,13 +41,9 @@ The EC and SSC share responsibility for approving:
 
 In these decisions, each body will [vote](decision_making.md) independently and the change will be approved only if both bodies approve.
 
-### Contacting the Executive Council
+### Team Compass
 
-To contact the EC, at your preference you may:
-
-* Email the [EC mailing list](mailto:jupyter-executive-council@googlegroups.com) (this list is private but open for posting).
-* Join the regular public office hours of the EC. See the [Jupyter Community Calendar](https://discourse.jupyter.org/t/jupyter-community-calendar/2485) for details.
-* Open a new issue on the [EC Team Compass](https://github.com/jupyter/executive-council-team-compass/issues/new).
+The [Executive Council Team Compass](https://executive-council-team-compass.readthedocs.io/en/latest/) publishes information about the activities and operations of the EC, including how to contact the EC.
 
 ## Council membership and elections
 


### PR DESCRIPTION
## Questions to answer ❓



### Background or context to help others understand the change.

### A brief summary of the change.

This points to the team compass as the way to find out information about EC activities and contact information.

### What is the reason for this change?

### Alternatives to making this change and other considerations.


> ## The process ❗
> 
> The process for changing the governance pages is as follows:
> 
> * Open a pull request **in draft state**. This triggers a discussion and iteration phase
>   for your proposed changes.
> * When you believe enough discussion has happened,
>   **move the pull request to an active state**. This triggers a vote.
> * During the voting phase, no substantive changes may be made to the pull request.
> * The Executive Council and Software Steering Council will vote, and at the end of voting the pull request is merged or closed.
> 
> The discussion phase is meant to gather input and multiple perspectives from the community.
> Make sure that the community has had an opportunity to weigh in on
> the change **before calling a vote**. A good rule of thumb is to ask several Council
> members if they believe that it is time for a vote, and to let at least one person review
> the pull request for structural quality and typos.
