### PR TITLE
Merge Foundations and Standards subprojects

### DIFF
--- a/list_of_subprojects.md
+++ b/list_of_subprojects.md
@@ -22,8 +22,7 @@ The following Jupyter Subprojects have their own formal Subproject Council that 
   - [jupyter-xeus](https://github.com/jupyter-xeus/)
   - [IPykernel](https://github.com/ipython/ipykernel)
   - [IPython](https://github.com/ipython/ipython)
-- Jupyter Foundations
-- Jupyter Standards
+- Jupyter Foundations and Standards
 - [Jupyter Security](https://github.com/jupyter/security)
 - [Jupyter Accessibility](https://github.com/jupyter/accessibility)
 
@@ -50,14 +49,13 @@ The Official Jupyter Subprojects document proposes a number of changes to how ou
 - Jupyter Kernels
   - To consolidate the project’s work on first-party kernels, we propose to establish a new official Subproject called _Jupyter Kernels_ and create a Github organization named jupyter-kernels for the work of the Subproject. All Xeus repositories (https://github.com/jupyter-xeus) will be moved into this organization. This Subproject will also govern the IPython GitHub organization, which will be left in place (https://github.com/ipython).
   - A new Subproject Council for this organization will be established, and they will elect an SSC delegate.
-- Jupyter Standards
+- Jupyter Foundations and Standards
   - Ultimately, because Jupyter standards are cross-project in nature, they are owned by the SSC. The mechanics of day-to-day management of the JEP repo will be decided by the SSC.
   - There are a number of repositories that encode project-wide standards and protocols. To consolidate work on these repositories, we propose to establish a new official Subproject called Jupyter Standards and create a Github organization named jupyter-standards for the work of the Subproject. The following repositories will be moved into this organization:
     - Jupyter Client (https://github.com/jupyter/jupyter_client)
     - Jupyter Notebook Format (https://github.com/jupyter/nbformat)
     - Documentation for other specifications maintained by other Subprojects, such as the Jupyter Widgets message specification, or the Jupyter Server REST APIs.
     - JEPs repo (https://github.com/jupyter/enhancement-proposals).
-- Jupyter Foundations
   - Jupyter’s software has a number of components that serve as a foundation for many other Subprojects. To consolidate work on these repositories, we propose to establish a new official Subproject called _Jupyter Foundations_ and create a Github organization named jupyter-foundations for the work of the Subproject. The following repositories will be moved into this organization:
     - nbconvert (https://github.com/jupyter/nbconvert)
     - Jupyter Core (https://github.com/jupyter/jupyter_core)

--- a/people.md
+++ b/people.md
@@ -17,12 +17,11 @@ Alphabetical by first name, names are followed by GitHub usernames.
 | Subproject | Representative | GitHub username |
 | ---------- | -------------- | --------------- |
 | Jupyter Accessibility | Isabela Presedo-Floyd | [@isabela-pf](https://github.com/isabela-pf) |
-| Jupyter Foundations | Paul Ivanov | [@ivanov](https://github.com/ivanov) |
+| Jupyter Foundations and Standards | Paul Ivanov | [@ivanov](https://github.com/ivanov) |
 | Jupyter Kernels | Johan Mabille | [@johanmabille](https://github.com/johanmabille) |
 | Jupyter Notebook | Eric Charles | [@echarles](https://github.com/echarles) |
 | Jupyter Security | Rick Wagner | [@rpwagner](https://github.com/rpwagner) |
 | Jupyter Server | Zach Sailer | [@zsailer](https://github.com/zsailer) |
-| Jupyter Standards | Carol Willing | [@willingc](https://github.com/willingc) |
 | Jupyter Widgets | Itay Dafna | [@ibdafna](https://github.com/ibdafna) |
 | JupyterHub and Binder | Min Ragan-Kelley | [@minrk](https://github.com/minrk) |
 | JupyterLab | Frédéric Collonval | [@fcollonval](https://github.com/fcollonval) |


### PR DESCRIPTION
This PR merges the Foundations and Standards projects into a single subproject. This was discussed with both Carol and Paul and both agreed to make this change.

CC @afshin 

## Executive Council

- @afshin
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @ellisonbg
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @jasongrout
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @fperez
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @Ruv7
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @blink1073 
  - [x] Yes
  - [ ] No
  - [ ] Abstain

## Software Steering Council

- @echarles 
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @fcollonval 
  - [x] Yes
  - [ ] No 
  - [ ] Abstain
- @ibdafna 
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @isabela-pf 
  - [x] Yes 
  - [ ] No
  - [ ] Abstain
- @ivanov
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @JohanMabille 
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @minrk
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @rpwagner 
  - [x] Yes
  - [ ] No
  - [ ] Abstain 
- @SylvainCorlay
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @willingc
  - [ ] Yes
  - [ ] No
  - [ ] Abstain
- @Zsailer 
  - [x] Yes
  - [ ] No 
  - [ ] Abstain
