### PR TITLE
Make the joint EC/SSC responsibility language the same in both EC and…

### DIFF
--- a/software_steering_council.md
+++ b/software_steering_council.md
@@ -23,11 +23,13 @@ The SSC is responsible for the following:
 
 ### Shared responsibilities with the Executive Council
 
-The SSC and EC share the responsibility for:
+The EC and SSC share responsibility for approving:
 
 - Changes to the Jupyter Governance model.
 - Creation of new Jupyter Subprojects.
 - Removal of Subprojects from Jupyter.
+
+In these decisions, each body will [vote](decision_making.md) independently and the change will be approved only if both bodies approve.
 
 ## Membership
 


### PR DESCRIPTION
## Questions to answer ❓

### Background or context to help others understand the change.

The wording of the joint EC/SSC responsibilities is slightly different between the EC and SSC docs, which may introduce confusion.

### A brief summary of the change.

This aligns the wording between the docs to be identical. 

### What is the reason for this change?

To avoid confusion from slightly different wording between the two documents.

### Alternatives to making this change and other considerations.


> ## The process ❗
> 
> The process for changing the governance pages is as follows:
> 
> * Open a pull request **in draft state**. This triggers a discussion and iteration phase
>   for your proposed changes.
> * When you believe enough discussion has happened,
>   **move the pull request to an active state**. This triggers a vote.
> * During the voting phase, no substantive changes may be made to the pull request.
> * The Executive Council and Software Steering Council will vote, and at the end of voting the pull request is merged or closed.
> 
> The discussion phase is meant to gather input and multiple perspectives from the community.
> Make sure that the community has had an opportunity to weigh in on
> the change **before calling a vote**. A good rule of thumb is to ask several Council
> members if they believe that it is time for a vote, and to let at least one person review
> the pull request for structural quality and typos.

I believe this is just a wording alignment and does not represent a shift in actual governance, and hence does not need a full vote.