### PR TITLE
Add Martha Cryan to the SSC people list as the DEI working group representative

### DIFF
--- a/people.md
+++ b/people.md
@@ -16,6 +16,7 @@ Alphabetical by first name, names are followed by GitHub usernames.
 
 | Subproject | Representative | GitHub username |
 | ---------- | -------------- | --------------- |
+| DEI Working Group | Martha Cryan | [@marthacryan](https://github.com/marthacryan) |
 | Jupyter Accessibility | Gabriel Fouasnon | [@gabalafou](https://github.com/gabalafou) |
 | Jupyter Foundations and Standards | Paul Ivanov | [@ivanov](https://github.com/ivanov) |
 | Jupyter Kernels | Johan Mabille | [@johanmabille](https://github.com/johanmabille) |


### PR DESCRIPTION
Add @marthacryan to the SSC people list as the DEI Working Group Representative. 

Welcome, @marthacryan! 🎉 