### PR TITLE
Update docs for Media Strategy Working Group

### DIFF
--- a/people.md
+++ b/people.md
@@ -44,6 +44,13 @@ Alphabetical by first name, names are followed by GitHub usernames.
 - Martha Cryan, [@marthacryan](https://github.com/marthacryan)
 - Rollin Thomas, [@rcthomas](https://github.com/rcthomas)
 
+### [Jupyter Media Strategy Working Group](charters/MediaStrategyCharter.md)
+
+- Ana Ruvalcaba, [@Ruv7](https://github.com/Ruv7)
+- Steven Silvester, [@blink1073](https://github.com/blink1073)
+- Andrii Ieroshenko, [@andrii-i](https://github.com/andrii-i)
+- Jacob Diamond-Reivich, [@jake-stack](https://github.com/jake-stack)
+
 ## Former Project Jupyter Leadership
 
 Prior to December 2022, Jupyter was led by a Benevolent Dictator for Life (BDFL)

--- a/standing_committees_and_working_groups.md
+++ b/standing_committees_and_working_groups.md
@@ -4,7 +4,7 @@
 
 In addition to the software work on Jupyter that is coordinated through the [Software Steering Council](software_steering_council.md) (SSC), much of the project’s work expands beyond software. Examples include code of conduct incident response, diversity and inclusion, operations, legal, fundraising, events, community, and marketing. Standing Committees and Working Groups carry out this non-software related work of the project by delegation from the [Executive Council](executive_council).
 
-The primary difference between Standing Committees and Working Groups is that Standing Committees are intended to be permanent; they are only created and dissolved by a joint vote of the EB and SSC. In contrast, Working Groups can be created and dissolved by the EB acting alone.
+The primary difference between Standing Committees and Working Groups is that Standing Committees are intended to be permanent; they are only created and dissolved by a joint vote of the EC and SSC. In contrast, Working Groups can be created and dissolved by the EC acting alone.
 
 A list of Standing Committees and Working Groups can be [found here](list_of_standing_committees_and_working_groups.md).
 
@@ -23,16 +23,16 @@ Standing Committees and Working Groups both:
 
 Standing Committees have the following unique properties:
 
-- Standing Committees focus on areas critical to the governance of the project and thus are established and dissolved by joint decisions of the SSC and EB.
-- Changes to the charters of Standing Committees are approved by joint decisions of the SSC and EB.
+- Standing Committees focus on areas critical to the governance of the project and thus are established and dissolved by joint decisions of the SSC and EC.
+- Changes to the charters of Standing Committees are approved by joint decisions of the SSC and EC.
 - Standing Committees always have a representative on the SSC, elected by the Standing Committee Council.
-- The EB is responsible for ensuring the Standing Committees are appropriately resourced at all times.
+- The EC is responsible for ensuring the Standing Committees are appropriately resourced at all times.
 
 ## Working Groups
 
 Working Groups have the following unique properties:
 
-- Working Groups are established and dissolved by decisions of EB.
-- Changes to the charters of Working Groups are approved by the EB.
+- Working Groups are established and dissolved by decisions of EC.
+- Changes to the charters of Working Groups are approved by the EC.
 - Working Groups, by default, do not have representatives on the SSC.
-- Optionally, the EB may nominate certain Working Groups to have a representative on the SSC. Once approved by the SSC to have a representative on the SSC, Working Group councils elect and maintain their representative to the SSC using the Decision-Making Guide.
+- Optionally, the EC may nominate certain Working Groups to have a representative on the SSC. Once approved by the SSC to have a representative on the SSC, Working Group councils elect and maintain their representative to the SSC using the Decision-Making Guide.


### PR DESCRIPTION
Follow up to #181.  Also fixes a few typos where "EB" was still used instead of "EC".