### PR TITLE
Fix broken link to CoC enforcement

### DIFF
--- a/conduct/code_of_conduct.md
+++ b/conduct/code_of_conduct.md
@@ -146,7 +146,7 @@ report, we will take appropriate action.
 ## Enforcement
 
 For information on enforcement, please view the [*Enforcement
-Manual*](enforcement).
+Manual*](enforcement.md).
 
 Original text courtesy of the [*Speak
 Up!*](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html)

--- a/conduct/reporting_online.md
+++ b/conduct/reporting_online.md
@@ -50,7 +50,7 @@ means we may delay an "official" response until we believe that the situation
 has ended and that everyone is physically safe.
 
 The Code of Conduct committee will then follow the
-[standard procedure](enforcement.md#Resolutions) to arrive at and
+[standard procedure](enforcement.md) to arrive at and
 communicate a resolution.
 
 


### PR DESCRIPTION
Fixes a broken link from `governance/conduct/code_of_conduct.md` to `…/enforcement.md`, as first observed by @adriens in https://github.com/jupyterlab/jupyter-ai/pull/577#issuecomment-1889973884 — thanks!