### PR TITLE
Merge Lab and Notebook Subprojects

### DIFF
--- a/list_of_subprojects.md
+++ b/list_of_subprojects.md
@@ -6,7 +6,7 @@ At the highest level, any Github repository under any official Jupyter GitHub or
 
 The following Jupyter Subprojects have their own formal Subproject Council that elects and maintains an SSC representative:
 
-- [JupyterLab](https://github.com/jupyterlab/team-compass)
+- [Jupyter Frontends](https://github.com/jupyterlab/team-compass) and [additional link](https://github.com/jupyter/notebook-team-compass)
 - [JupyterHub and Binder](https://github.com/jupyterhub/team-compass)
   - [Jupyterhub](https://github.com/jupyterhub/jupyterhub)
   - [Binder](https://github.com/jupyterhub/binder)
@@ -17,7 +17,6 @@ The following Jupyter Subprojects have their own formal Subproject Council that 
   - [Enterprise Gateway](https://github.com/jupyter/enterprise_gateway)
   - [Kernel Gateway](https://github.com/jupyter/kernel_gateway)
 - [Jupyter Widgets](https://github.com/jupyter-widgets/team-compass)
-- [Jupyter Notebook](https://github.com/jupyter/notebook-team-compass)
 - [Jupyter Kernels](https://github.com/jupyter/kernels-team-compass)
   - [jupyter-xeus](https://github.com/jupyter-xeus/)
   - [IPykernel](https://github.com/ipython/ipykernel)

--- a/list_of_subprojects.md
+++ b/list_of_subprojects.md
@@ -6,7 +6,7 @@ At the highest level, any Github repository under any official Jupyter GitHub or
 
 The following Jupyter Subprojects have their own formal Subproject Council that elects and maintains an SSC representative:
 
-- [Jupyter Frontends](https://github.com/jupyterlab/team-compass) and [additional link](https://github.com/jupyter/notebook-team-compass)
+- [Jupyter Frontends](https://github.com/jupyterlab/team-compass)
 - [JupyterHub and Binder](https://github.com/jupyterhub/team-compass)
   - [Jupyterhub](https://github.com/jupyterhub/jupyterhub)
   - [Binder](https://github.com/jupyterhub/binder)


### PR DESCRIPTION
### Proposal

Merge the JupyterLab and Jupyter Notebook sub-projects into a single Jupyter Frontends sub-project

### Description

Jupyter Notebook 7 has now been available for a couple of months (final was released in July 2023). There is a migration guide for Classic Notebook (v6) users, but now most of the development work is focused on Notebook 7.

As Notebook 7 is built on top of JupyterLab, there seems to be more overlap between the JupyterLab and Jupyter Notebook subprojects, in terms of scope, community, features, code base, and contributors.

For end users, installing the notebook package also brings the jupyterlab package automatically. Both JupyterLab and Jupyter Notebook also offer UI elements to seamlessly switch between the two user interfaces.

For contributors and maintainers, the Notebook 7 application is a simpler JupyterLab re-assembled in a different way. So developers who are familiar with JupyterLab development would also be comfortable working on Notebook 7, since they both follow the same structure and extension system.

For JupyterLab and Jupyter Notebook developers, merging the two sub-projects would help catch potential issues from decisions and technical choices happening upstream in JupyterLab, which can have an impact downstream in Notebook 7.

In other words, merging the sub-projects would help put Notebook 7 on the radar and keep the Notebook 7 use case in mind when designing features or making changes in JupyterLab. This would benefit end users as developing the two frontends more closely could help improve UX, general design decisions, and accessibility.

### References

Original discussion: https://github.com/jupyterlab/team-compass/issues/230

### EC members/voting checkboxes

* @afshin
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @ellisonbg
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @jasongrout
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @fperez
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @Ruv7
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @blink1073
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain

### SSC members/voting checkboxes

* @marthacryan
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @gabalafou
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @ivanov
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @johanmabille
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @echarles
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @rpwagner
  * [ ]  Yes
  * [ ]  No
  * [ ]  Abstain
* @zsailer
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @ibdafna
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @minrk
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @fcollonval
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @SylvainCorlay
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
