### PR TITLE
Update from lab/nb to frontends

### DIFF
--- a/list_of_subprojects.md
+++ b/list_of_subprojects.md
@@ -7,6 +7,8 @@ At the highest level, any Github repository under any official Jupyter GitHub or
 The following Jupyter Subprojects have their own formal Subproject Council that elects and maintains an SSC representative:
 
 - [Jupyter Frontends](https://github.com/jupyterlab/team-compass)
+  - [JupyterLab](https://github.com/jupyterlab/jupyterlab)
+  - [Jupyter Notebook](https://github.com/jupyter/notebook)
 - [JupyterHub and Binder](https://github.com/jupyterhub/team-compass)
   - [Jupyterhub](https://github.com/jupyterhub/jupyterhub)
   - [Binder](https://github.com/jupyterhub/binder)

--- a/people.md
+++ b/people.md
@@ -19,13 +19,12 @@ Alphabetical by first name, names are followed by GitHub usernames.
 | DEI Standing Committee | Martha Cryan | [@marthacryan](https://github.com/marthacryan) |
 | Jupyter Accessibility | Gabriel Fouasnon | [@gabalafou](https://github.com/gabalafou) |
 | Jupyter Foundations and Standards | Paul Ivanov | [@ivanov](https://github.com/ivanov) |
+| Jupyter Frontends | Jérémy Tuloup | [@jtpio](https://github.com/jtpio) |
 | Jupyter Kernels | Johan Mabille | [@johanmabille](https://github.com/johanmabille) |
-| Jupyter Notebook | Eric Charles | [@echarles](https://github.com/echarles) |
 | Jupyter Security | Rick Wagner | [@rpwagner](https://github.com/rpwagner) |
 | Jupyter Server | Zach Sailer | [@zsailer](https://github.com/zsailer) |
 | Jupyter Widgets | Itay Dafna | [@ibdafna](https://github.com/ibdafna) |
 | JupyterHub and Binder | Min Ragan-Kelley | [@minrk](https://github.com/minrk) |
-| JupyterLab | Frédéric Collonval | [@fcollonval](https://github.com/fcollonval) |
 | Voilà | Sylvain Corlay | [@SylvainCorlay](https://github.com/SylvainCorlay) |
 
 ### Trademark Subcommittee


### PR DESCRIPTION
Update the software steering council to reflect the merge of lab and notebook into the new frontends sub-project.
And mention that Jérémy is now the SSC representative of that new subgroup.

cc @echarles @jtpio 