### PR TITLE
Add a pointer to EC contact info for other avenues for discussion

### DIFF
--- a/linux-proposal.md
+++ b/linux-proposal.md
@@ -2,7 +2,7 @@
 
 March 5, 2024
 
-*Discussion of this proposal is at https://github.com/jupyter/governance/issues/204.*
+*Discussion of this proposal is at https://github.com/jupyter/governance/issues/204. You can also [contact the EC](https://executive-council-team-compass.readthedocs.io/en/latest/#contacting-the-executive-council) in the EC office hours or by private email to share your thoughts.*
 
 # Executive Summary
 


### PR DESCRIPTION
This points to a few more avenues for people to contact the EC either in office hours or by private email if they'd rather convey their thoughts synchronously or privately.