### PR TITLE
Update election docs to link to STeVe script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ target/
 
 # Docs
 _build
+
+# macOS
+.DS_Store

--- a/elections/README.md
+++ b/elections/README.md
@@ -2,7 +2,7 @@
 
 The script in this directory converts a comma-separated value (CSV) file
 from a Jupyter Executive Council election into an `.ini` file and a `.txt`
-file for use with the Apache STeVe script `stv_tool.py`. After running 
+file for use with the Apache STeVe script `stv_tool.py`. After running
 this latter script, which is stored in the
 [apache/steve project](https://github.com/apache/steve), you will determine
 which candidates have won.
@@ -82,7 +82,7 @@ slate would have their vote represented as `abc`.
 From the directory where you have `votes.csv`, run `process-votes.py`.
 
 This script produces `board_nominations.ini` and `votedata.txt` for use
-with the Apache STeVe tabulation script. Run this script, passing the
+with the [Apache STeVe tabulation script (`stv_tool.py`)](https://github.com/apache/steve/blob/trunk/monitoring/stv_tool.py). Run this script, passing the
 number of seats to elect with the `-s` parameter. In the example below,
 the tabulation script will select two winners. You can get more verbose
 output using the `-v` parameter.

--- a/elections/process-votes.py
+++ b/elections/process-votes.py
@@ -32,9 +32,9 @@ with open('votedata.txt', 'w') as vote_output:
         candidate_alphas = [' '] * len(candidate_priorities)
 
         for idx, c in enumerate(candidate_priorities):
-            if (re.search('\d', c)):
+            if (re.search(r'\d', c)):
                 candidate_alphas[int(c) - 1] = letters[idx]
-        
+
         # This is normally to dedupe multiple votes by the same voter,
         # but Google Forms already does that, so we instead assume that
         # every vote is unique and cast at the current time


### PR DESCRIPTION
This PR updates the election tabulation instructions to include a link to the STeVe script in the `apache/steve` repo.