### PR TITLE
trademarks: allow base domains where organization is clear

### DIFF
--- a/trademarks.md
+++ b/trademarks.md
@@ -199,9 +199,10 @@ The following rules apply to the use of trademarks in each of these classes.
 - Use of the word "Jupyter" in another trademark --
   Not allowed without prior written permission from Jupyter, except as described above.
 - Use of the word "Jupyter" in a domain name --
-  Allowed in subdomains and url-paths,
+  Allowed in subdomains and url paths,
   such as "jupyter.example.com" and "example.com/jupyter".
-  Not allowed in base domains, such as "jupytercloud.com" or "hostedjupyter.horse".
+  Allowed in base domains where the organization responsible for the service is clear in the name itself, e.g. "myorganization-jupyter.org" or "uoffoojupyterusers.edu".
+  Not allowed in base domains on its own or with only generic terms, such as "jupytercloud.com" or "hostedjupyter.horse".
 
 
 ### Unaltered Logos


### PR DESCRIPTION
The goal of the domain rules is to avoid confusion about whether a service is affiliated with the Jupyter project. Make it explicit that such confusion can still be resolved in the base domain itself.

For secure deployment reasons like cookie tossing, we should be _recommending_ hosted jupyter deployments be on their own domain (for the same reasons github has githubusercontent.com and github.io). The trademark policy shouldn't make it harder for folks to follow best practices.