### PR TITLE
Require using the Jupyter Enterprise Org

### DIFF
--- a/list_of_subprojects.md
+++ b/list_of_subprojects.md
@@ -1,6 +1,6 @@
 # List of Official Jupyter Subprojects
 
-At the highest level, any Github repository under any official Jupyter GitHub organization is either itself an Official Jupyter Subproject, or is part of an Official Jupyter Subproject. All such Subprojects have all of the privileges and responsibilities detailed in the Software Subprojects of Jupyter governance document. Within the Official Jupyter Subproject designation, there are two types of Subprojects: ones with a formal Subproject Council and SSC representation, and smaller, less active ones whose Subproject Council is the SSC itself. This document enumerates Subprojects of these two types.
+Jupyter software development is carried out in [Software Subprojects](./software_subprojects). Within the Official Jupyter Subproject designation, there are two types of Subprojects: ones with a formal Subproject Council and SSC representation, and smaller, less active ones whose Subproject Council is the SSC itself. This document enumerates Subprojects of these two types.
 
 ## Official Subprojects with SSC representation
 

--- a/software_subprojects.md
+++ b/software_subprojects.md
@@ -2,8 +2,6 @@
 
 Software design and development in Project Jupyter is organized into a set of Software Subprojects. The lifecycle of Software Subprojects is described in detail [here](newsubprojects.md). A list of Subprojects is [here](./list_of_subprojects.md).
 
-Software Subprojects often carry out their work in GitHub repositories/organizations. Any Subproject repositories or organizations that are on GitHub must belong to the [Project Jupyter GitHub enterprise organization](https://github.com/enterprises/jupyter). This enables Project Jupyter to have consistent policies across all of Jupyter while enabling Subprojects to have autonomy in their GitHub orgs and repositories.
-
 ## Responsibilities of Jupyter Subprojects
 
 Unless the [Software Steering Council (SSC)](./software_steering_council.md) or the [Executive Council (EC)](./executive_council.md) says otherwise, Subprojects self-govern as autonomously as possible, while following the overall governance model and processes of Project Jupyter. Specifically, all Subprojects under Jupyter’s governance have the following responsibilities:
@@ -14,7 +12,8 @@ Unless the [Software Steering Council (SSC)](./software_steering_council.md) or 
 - Follow the Jupyter [licensing guidelines and practices](./projectlicense.md).
 - Follow the Jupyter [trademark, branding, and intellectual property guidelines](./trademarks.md).
 - Conduct its activities in a manner that is open, transparent, and inclusive. This includes coordinating with the SSC and EC on mechanisms for information flow and updates to the broader community.
-- Maintain a publicly visible Team Compass with a list of the Council members.
+- Maintain Subproject source code on GitHub in the [Project Jupyter GitHub enterprise organization](https://github.com/enterprises/jupyter).
+- Maintain a publicly visible Team Compass with a list of the Subproject Council members.
 
 ## Incubator Subprojects
 

--- a/software_subprojects.md
+++ b/software_subprojects.md
@@ -1,18 +1,20 @@
 # Software Subprojects
 
-Software design and development in Project Jupyter is organized into a set of Software Subprojects. These software Subprojects often map onto GitHub repositories/organizations, but that is not strictly required. The lifecycle of Software Subprojects is [described in detail here](newsubprojects.md).
+Software design and development in Project Jupyter is organized into a set of Software Subprojects. The lifecycle of Software Subprojects is described in detail [here](newsubprojects.md). A list of Subprojects is [here](./list_of_subprojects.md).
+
+Software Subprojects often carry out their work in GitHub repositories/organizations. Any Subproject repositories or organizations that are on GitHub must belong to the [Project Jupyter GitHub enterprise organization](https://github.com/enterprises/jupyter). This enables Project Jupyter to have consistent policies across all of Jupyter while enabling Subprojects to have autonomy in their GitHub orgs and repositories.
 
 ## Responsibilities of Jupyter Subprojects
 
-Unless the Software Steering Council (SSC) or the Executive Council (EC) says otherwise, Subprojects self-govern as autonomously as possible, while following the overall governance model and processes of Project Jupyter. Specifically, all Subprojects under Jupyter’s governance have the following responsibilities:
+Unless the [Software Steering Council (SSC)](./software_steering_council.md) or the [Executive Council (EC)](./executive_council.md) says otherwise, Subprojects self-govern as autonomously as possible, while following the overall governance model and processes of Project Jupyter. Specifically, all Subprojects under Jupyter’s governance have the following responsibilities:
 
-- Adhere to the Jupyter Code of Conduct.
+- Adhere to the [Jupyter Code of Conduct](./conduct/code_of_conduct.md).
 - Adhere to the [Jupyter Decision-Making Guidelines and process](decision_making.md).
 - Where applicable, nominate and maintain a single representative to the SSC.
-- Follow the licensing guidelines and practices of the project ([use of the BSD license and copyright header](https://github.com/jupyter/jupyter/blob/master/LICENSE)).
-- Follow Jupyter’s trademark, branding, and intellectual property guidelines.
-- Conduct its activities in a manner that is open, transparent, and inclusive. This includes coordinating with the Software Steering Council and the Executive Council on mechanisms for information flow and updates to the broader community (details of this, project-wide, will be developed as our new governance model is adopted and implemented).
-- Maintain a publicly visible Team Compass with a list of the Council members (see e.g. [JupyterHub](https://github.com/jupyterhub/team-compass) or [Jupyter Frontends](https://github.com/jupyterlab/frontends-team-compass) for illustration of their structure and content).
+- Follow the Jupyter [licensing guidelines and practices](./projectlicense.md).
+- Follow the Jupyter [trademark, branding, and intellectual property guidelines](./trademarks.md).
+- Conduct its activities in a manner that is open, transparent, and inclusive. This includes coordinating with the SSC and EC on mechanisms for information flow and updates to the broader community.
+- Maintain a publicly visible Team Compass with a list of the Council members.
 
 ## Incubator Subprojects
 


### PR DESCRIPTION
## Questions to answer ❓

### Background or context to help others understand the change.

Currently Project Jupyter development on GitHub is spread across a number of GitHub orgs. This provides autonomy for subprojects to maintain their own contributor lists, roles, and processes. However, as the number of GitHub orgs in Jupyter increases, it also causes confusion about the scope of official Jupyter activities and increases friction for Jupyter-wide policies.

Recently, GitHub offered Jupyter (and other open-source projects) a free upgrade to their [GitHub Enterprise Cloud plan](https://docs.github.com/en/enterprise-cloud@latest/admin/overview/about-github-enterprise-cloud). The basic idea is that Project Jupyter would have an Enterprise org, and inside that enterprise org we have our existing GitHub orgs. The enterprise org provides a place to centrally manage policies and roles across all of the Jupyter GitHub orgs, while still enabling individual subprojects to maintain their individual GitHub orgs.

This upgrade helps solve pain points we've had with multiple GitHub orgs in Jupyter. For example:
* Recently the Jupyter Security subproject enabled 2FA across all of the Jupyter GitHub orgs, and this required a nontrivial amount of work to follow through on each individual GitHub org. With an enterprise org, enabling 2FA across all of the Jupyter GitHub orgs would have been single checkbox at the enterprise org level.
* We've had a tension between creating more orgs to better reflect the autonomy of subprojects and the desire to keep the orgs to a manageable number (see discussion [here](https://github.com/jupyter-governance/ec-team-compass/issues/12), [here](https://github.com/jupyter/enhancement-proposals/issues/122), and [here](https://github.com/jupyter-governance/ec-team-compass/issues/25), for example). A centralized place to manage policies and roles would hopefully resolve that tension, and we can give all subprojects the autonomy of their own GitHub org if desired. 
* Sometimes this tension for creating new GitHub orgs for subprojects has led to having multiple subprojects share a single GitHub org. When this happens, org-based roles for one subproject often grant permissions for another subproject in the same GitHub org that were not intended, infringing on the autonomy of subprojects.
* With the number of GitHub orgs in Jupyter, there is confusion about the scope and spaces of official Jupyter activities (see comments [here](https://github.com/jupyter-governance/ec-team-compass/issues/12), for example). We maintain manually a list of some of the GitHub orgs in the list of subprojects, but there are additional orgs under the Jupyter umbrella, such as the [incubator org](https://github.com/jupyter-incubator) and the [EC org](https://github.com/jupyter-governance). If all Jupyter orgs belonged to a single umbrella Enterprise org, it would clarify where official Jupyter development spaces are.

Furthermore, using the enterprise org gives additional benifits, such as:
* higher limits for [CI and other resources](https://github.com/pricing)
* the ability to [create custom permission roles](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/about-custom-repository-roles)

Based on this information, the Executive Council recently made the decision to create a [Project Jupyter enterprise org](https://github.com/enterprises/jupyter), and we reached out to the SSC about having various Jupyter GitHub orgs join the enterprise org. At this point, many have joined.

There is further discussion of this at https://github.com/jupyter/governance/issues/219.

### A brief summary of the change.

In this change, we require official Jupyter GitHub orgs to belong to the new [Jupyter enterprise GitHub org](https://github.com/enterprises/jupyter). We also simplify other text in the subproject governance.

### What is the reason for this change?

To make it easier to have consistency across Jupyter GitHub orgs, while still enabling autonomy for subprojects.

### Alternatives to making this change and other considerations.

* We could continue with our current practice of creating new GitHub orgs as we adopt new subprojects. However, it seems that every time a new subproject joins Jupyter, the discussion of the proliferation of GitHub orgs comes up. For example, [here](https://github.com/jupyter/enhancement-proposals/issues/122), and [here](https://github.com/jupyter-governance/ec-team-compass/issues/25).
* We could consolidate all development under a single or very few GitHub orgs, as suggested [here](https://github.com/jupyter-governance/ec-team-compass/issues/12). However, as mentioned above, this makes it harder for Subprojects to have autonomy in their permissions and operations.

## Voting

Vote is expected to close in 2 weeks, June 19.

### EC members/voting checkboxes

* @afshin
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @ellisonbg
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @jasongrout
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @fperez
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @Ruv7
  * [ ]  Yes
  * [ ]  No
  * [x]  Abstain
* @zsailer
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain

### SSC members/voting checkboxes

* @marthacryan: DEI
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @gabalafou: Jupyter Accessibility
  * [ ]  Yes
  * [ ]  No
  * [ ]  Abstain
* @ivanov: Jupyter Foundations and Standards
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @jtpio: Jupyter Frontends
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @johanmabille: Jupyter Kernels
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @rpwagner: Jupyter Security
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @vidartf: Jupyter Server
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @SylvainCorlay: Jupyter Widgets
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @minrk: JupyterHub and Binder
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain
* @martinRenou: Voilà
  * [x]  Yes
  * [ ]  No
  * [ ]  Abstain

> ## The process ❗
> 
> The process for changing the governance pages is as follows:
> 
> * Open a pull request **in draft state**. This triggers a discussion and iteration phase
>   for your proposed changes.
> * When you believe enough discussion has happened,
>   **move the pull request to an active state**. This triggers a vote.
> * During the voting phase, no substantive changes may be made to the pull request.
> * The Executive Council and Software Steering Council will vote, and at the end of voting the pull request is merged or closed.
> 
> The discussion phase is meant to gather input and multiple perspectives from the community.
> Make sure that the community has had an opportunity to weigh in on
> the change **before calling a vote**. A good rule of thumb is to ask several Council
> members if they believe that it is time for a vote, and to let at least one person review
> the pull request for structural quality and typos.

