### PR TITLE
Add e-mails for SSC and EC

### DIFF
--- a/executive_council.md
+++ b/executive_council.md
@@ -2,6 +2,12 @@
 
 The current members of the Executive Council are listed in the [Leadership Directory](people).
 
+```{card} See the team compass for more information.
+:link: https://executive-council-team-compass.readthedocs.io/en/latest/
+The Executive Council Team Compass has more information about operations, meetings, e-mail and contact info, etc.
+Click here to go there.
+```
+
 ## Purpose
 
 The Executive Council (EC) is ultimately responsible for all dimensions of the Project (including, but not limited to, software, legal, financial, community, operations, inclusion and diversity, etc.). The members of the EC actively work to carry out the Project's mission in accordance with its values and to support operations through delegation to the Software Steering Council (SSC), Software Subprojects, Standing Committees, and Working Groups. These other bodies will report to the EC, and the EC is expected to support, oversee, manage, and ensure the success of operations across Jupyter.
@@ -56,13 +62,6 @@ If a member leaves the council before the end of their term, the EC may designat
 A person may not serve simultaneously on the EC and SSC.
 
 The EC may vote to remove an EC member. A removal motion passes if two-thirds of the entire EC votes in favor of removal. All EC members are expected to vote without recusal, including the member in question.
-
-## Communication
-
-### E-mail list
-
-You can e-mail the Executive Council [at this Google Groups address](jupyter-executive-council@googlegroups.com).
-
 
 ## Bootstrapping the Executive Council
 

--- a/executive_council.md
+++ b/executive_council.md
@@ -57,6 +57,13 @@ A person may not serve simultaneously on the EC and SSC.
 
 The EC may vote to remove an EC member. A removal motion passes if two-thirds of the entire EC votes in favor of removal. All EC members are expected to vote without recusal, including the member in question.
 
+## Communication
+
+### E-mail list
+
+You can e-mail the Executive Council [at this Google Groups address](jupyter-executive-council@googlegroups.com).
+
+
 ## Bootstrapping the Executive Council
 
 The process to create the initial Executive Council is [described in this document](bootstrapping_executive_council.md).

--- a/executive_council.md
+++ b/executive_council.md
@@ -2,10 +2,10 @@
 
 The current members of the Executive Council are listed in the [Leadership Directory](people).
 
-```{card} See the team compass for more information.
+```{card} Click here for the team compass.
 :link: https://executive-council-team-compass.readthedocs.io/en/latest/
 The Executive Council Team Compass has more information about operations, meetings, e-mail and contact info, etc.
-Click here to go there.
+This page focuses on the governance aspects of the Executive Council.
 ```
 
 ## Purpose

--- a/executive_council.md
+++ b/executive_council.md
@@ -2,7 +2,7 @@
 
 The current members of the Executive Council are listed in the [Leadership Directory](people).
 
-```{card} Click here for the team compass.
+```{card} Click here for the team compass. 🧭
 :link: https://executive-council-team-compass.readthedocs.io/en/latest/
 The Executive Council Team Compass has more information about operations, meetings, e-mail and contact info, etc.
 This page focuses on the governance aspects of the Executive Council.

--- a/software_steering_council.md
+++ b/software_steering_council.md
@@ -54,3 +54,13 @@ Each Jupyter Subproject, Working Group, or Standing Committee with SSC represent
 ### Bootstrapping the SSC
 
 The initial Software Steering Council will be created with individuals nominated by each of the major Jupyter Subprojects, as defined by our [official list](list_of_subprojects.md).
+
+## Communication
+
+### Meetings
+
+Times for SSC meetings is defined [on the Jupyter Community Calendar](https://jupyter.org/community#calendar).
+
+### E-mail list
+
+You can e-mail the Software Steering Council [at this Google Groups address](jupyter-software-steering-council@googlegroups.com).


### PR DESCRIPTION
In a recent round of communication with the SSC, I couldn't find the listserv e-mail for the group. This adds brief information for how to get in touch with the SSC and the EC so that others aren't confused like I was.
