### PR TITLE
Add button to link to JCB reports and meeting minutes

### DIFF
--- a/communitybuildingworkinggroup.md
+++ b/communitybuildingworkinggroup.md
@@ -9,6 +9,12 @@ and Inclusion (DEI) standing committee.
 
 The current members of the Jupyter Community Building Working Group are listed in the [Leadership Directory](people).
 
+```{card} Click here for JCB reports and meeting minutes
+:link: https://executive-council-team-compass.readthedocs.io/en/latest/reports/communitybuilding/readme.html
+There is more information about meeting minutes and reports on group activities in the linked page.
+This page is the charter for the Jupyter Community Building Working Group.
+```
+
 ## Areas of responsibility
 
 ### Jupyter Community Workshops


### PR DESCRIPTION
Models the button off of the one at the top of [this page](https://jupyter.org/governance/executive_council.html). Links to the EC team compass [JCB page](https://executive-council-team-compass.readthedocs.io/en/latest/reports/communitybuilding/readme.html). 