### PR TITLE
Revert "Fix missing links in JMS charter"

### DIFF
--- a/charters/MediaStrategyCharter.md
+++ b/charters/MediaStrategyCharter.md
@@ -2,7 +2,8 @@
 
 ## Purpose
 
-The mission of the Jupyter Media Strategy Working Group (JMS) is to ensure that communications in Jupyter official channels are strategic and benefit Project Jupyter. The Jupyter [governance model](https://jupyter.org/governance/standing_committees_and_working_groups.html) includes a distributed model of responsibilities. This means that by design Jupyter publications, social media posts, promotions and other media activity are meant to be community driven. The JMS is vendor neutral and will provide mechanisms to enable the community to speak publicly through the official Jupyter communication channels. The JMS will also help to improve Jupyter media activity by creating strategy and guidelines, serving as editors for existing public media channels, and overseeing creation/delegation of new media channels.
+The mission of the Jupyter Media Strategy Working Group (JMS) is to ensure that communications in Jupyter official channels are strategic and benefit Project Jupyter. The Jupyter[ governance model ](https://jupyter.org/governance/standing_committees_and_working_groups.html)includes a distributed model of responsibilities. This means that by design Jupyter publications, social media posts, promotions and other media activity are meant to be community driven. The JMS is vendor neutral and will provide mechanisms to enable the community to speak publicly through the official Jupyter communication channels. The JMS will also help to improve Jupyter media activity by creating strategy and guidelines, serving as editors for existing public media channels, and overseeing creation/delegation of new media channels.
+
 
 # Editorial Principles
 
@@ -15,9 +16,10 @@ The JMS makes editorial decisions related to whether or not to accept/post conte
 - Social media channels will be used to amplify the reach of the blog. Posting on a particular platform is not an endorsement of that platform by Project Jupyter, but a means to communicate news to the Jupyter Community. With the exception of our preferred channel, we will use these channels to broadcast messages only, and will therefore not engage in two-way communication with users on said channels.
 - The working group will designate a preferred channel that it determines best reflects the values of Project Jupyter. This channel will be used for high bandwidth interactions such as event promotion and interacting with members of the community.
 
+
 ## Areas of responsibility
 
-This Working Group is responsible for two types of communication channels (e.g., blog, social media accounts, discussion forums, etc.). The list of official Jupyter communication channels is maintained separately [here](https://jupyter.org/social) by this Working Group and is intentionally not included as part of the group’s charter to allow operational flexibility. Areas of responsibility for the JMS include:
+This Working Group is responsible for two types of communication channels (e.g., blog, social media accounts, discussion forums, etc.). The list of official Jupyter communication channels is maintained separately here \[link] by this Working Group and is intentionally not included as part of the group’s charter to allow operational flexibility. Areas of responsibility for the JMS include:
 
 1. Creation and implementation of Jupyter Media Strategy, associated processes and guidelines
 2. Editorial oversight of channels where Project Jupyter is the primary stakeholder and editor (such as the blog).
@@ -27,9 +29,11 @@ This Working Group is responsible for two types of communication channels (e.g.,
 
 The focus of the JMS is to provide editorial guidance and oversight in these channels. This working group may create content and publicly use the official Jupyter voice (using Project Jupyter persona or speaking on behalf of Project Jupyter).
 
+
 ### Media Strategy Operations
 
-The JMS will create and maintain a media strategy page on the Jupyter website that shares guidance for how the Jupyter voice is managed. Jupyter subprojects, working groups, standing committees and their communities are encouraged to actively build awareness of themselves and their activities through emails, blog posts, social media posts, and other means of outreach using the processes and guidelines as outlined on a media strategy page on the https://jupyter.org/social.
+The JMS will create and maintain a media strategy page on the Jupyter website that shares guidance for how the Jupyter voice is managed. Jupyter subprojects, working groups, standing committees and their communities are encouraged to actively build awareness of themselves and their activities through emails, blog posts, social media posts, and other means of outreach using the processes and guidelines as outlined on a media strategy page on the Jupyter.org .
+
 
 ## Meetings
 


### PR DESCRIPTION
Reverts jupyter/governance#231

All - since the EC approves charters I think the EC needs to approve changes to charters. Reverting this back until we get feedback from the EC. This isn't urgent at this time and it makes sense to confirm that before moving forward. 