### PR TITLE
Bump GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,15 +10,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     # Install dependencies
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/*.md') }}
@@ -36,7 +36,7 @@ jobs:
         jupyter-book build .
 
     # Upload artifact
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: html_docs
         path: ./_build/html

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,15 +17,15 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     # Install dependencies
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/*.md') }}


### PR DESCRIPTION
Bump some GitHub actions, which should help fix the failure as seen in https://github.com/jupyter/governance/pull/236:

![image](https://github.com/user-attachments/assets/667df456-f8db-4a70-badb-addea1666b24)
