### PR TITLE
Update Jupyter Foundation Governing Board members.

### DIFF
--- a/people.md
+++ b/people.md
@@ -34,11 +34,14 @@ Alphabetical by first name, names are followed by GitHub usernames.
 | -------------- | ------------ | --------------- |
 | Afshin Darian | Executive Council | [@afshin](https://github.com/afshin) |
 | Ana Ruvalcaba | Executive Council | [@Ruv7](https://github.com/Ruv7) |
-| Brian Granger | Executive Council | [@ellisonbg](https://github.com/ellisonbg) |
-| Fernando Pérez | Executive Council | [@fperez](https://github.com/fperez) |
 | Jason Grout | Executive Council | [@jasongrout](https://github.com/jasongrout) |
 | Zach Sailer | Executive Council | [@Zsailer](https://github.com/zsailer) |
-
+| Brian Granger | AWS | [@ellisonbg](https://github.com/ellisonbg) |
+| Ben Bastian | Google | [@sagelywizard](https://github.com/sagelywizard) |
+| Rus Pandey | Apple |  |
+| Stephanie Stattel | Bloomberg |  |
+| Yaniv Schahar | Meta |  |
+| Vik Gupta | Snowflake |  |
 
 ### Trademark Subcommittee
 


### PR DESCRIPTION
Since the GB was formed, we've added a few member organizations, each with their own representative. Also, Brian is moving off of the EC, but is staying on the GB as AWS's rep. Fernando is also leaving the EC and therefore the GB.

I added my Github account to the list, but I don't know the GH accounts of the other new GB members. I'll send this PR around to the other GB members for review. Happy to add github accounts if they'd like!