### PR TITLE
Update JMS membership

### DIFF
--- a/people.md
+++ b/people.md
@@ -68,7 +68,6 @@ Alphabetical by first name, names are followed by GitHub usernames and current e
 
 ### [Jupyter Media Strategy Working Group](charters/MediaStrategyCharter.md)
 
-- Ana Ruvalcaba, [@Ruv7](https://github.com/Ruv7)
 - Andrii Ieroshenko, [@andrii-i](https://github.com/andrii-i)
 - Jacob Diamond-Reivich, [@jake-stack](https://github.com/jake-stack)
 - Sylvain Corlay, [@SylvainCorlay](https://github.com/SylvainCorlay)


### PR DESCRIPTION
Prompted by a question from @krassowski, I was checking this page, and realized that membership of the JMS was not updated when Ana left the group last month.

Ping @Ruv7.