### PR TITLE
Update config and add some links

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install jupyter-book
+        pip install -r requirements.txt
 
 
     # Build the book

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install jupyter-book
+        pip install -r requirements.txt
 
     # Build the book
     - name: Build the book

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,13 @@
 title                       : Project Jupyter Governance
 exclude_patterns            : ["LICENSE.md", "README.md", ".github"]
 copyright: ""
+repository:
+  url: https://github.com/jupyter/governance
+  path_to_book: .
+  branch: main
+
 html:
+  use_edit_page_button: true
   extra_footer: |
     <p xmlns:dct="http://purl.org/dc/terms/" xmlns:vcard="http://www.w3.org/2001/vcard-rdf/3.0#">
       <a rel="license"

--- a/executive_council.md
+++ b/executive_council.md
@@ -98,9 +98,9 @@ The EC may vote to remove an EC member. A removal motion passes if two-thirds of
 
 The Union of Councils (UoC) is the union of the membership of these groups:
 
-- All Subproject Councils
-- All Standing Committees
-- All Working Groups
+- All [Subproject Councils](#list-of-subprojects)
+- All [Standing Committees](#list-of-standing-committees)
+- All [Working Groups](#list-of-working-groups)
 
 It makes up the voting body that [elects members of the Executive Council](#ec-electors).
 

--- a/list_of_standing_committees_and_working_groups.md
+++ b/list_of_standing_committees_and_working_groups.md
@@ -2,6 +2,7 @@
 
 Project work that expands beyond software-related work is organized into chartered domains and is carried out by Standing Committees and Working Groups. A description of these bodies and their function can be found [here](standing_committees_and_working_groups.md). This document contains a list of the current Standing Committees and Working Groups with charter summaries and links to their GitHub repositories.
 
+(list-of-standing-committees)=
 ## Standing Committees
 
 ### Diversity, Equity, and Inclusion
@@ -20,6 +21,7 @@ Charter Summary: Ensure that the joint and conflicting interests of leaders acro
 
 Charter Summary: Advise the Executive Council (EC) with perspectives and connections that may reach beyond the active Jupyter community.
 
+(list-of-working-groups)=
 ## Working Groups
 
 ### Trademark and Branding

--- a/list_of_subprojects.md
+++ b/list_of_subprojects.md
@@ -1,3 +1,4 @@
+(list-of-subprojects)=
 # List of Official Jupyter Subprojects
 
 Jupyter software development is carried out in [Software Subprojects](./software_subprojects). Within the Official Jupyter Subproject designation, there are two types of Subprojects: ones with a formal Subproject Council and SSC representation, and smaller, less active ones whose Subproject Council is the SSC itself. This document enumerates Subprojects of these two types.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+jupyter-book<2


### PR DESCRIPTION
This is a minor change that does three things:

1. Adds an "edit this page" button to each page, which will link back to the github repo
2. Adds links to the relevant pages under the "Union of Councils" links
3. Pins Jupyter Book to < 2, since the 2.0 release will use a totally different build system and we'll need to upgrade.