### PR TITLE
Update links to use folders rather than `.html`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     # Build the book
     - name: Build the book
       run: |
-        jupyter-book build .
+        jupyter-book build . --builder dirhtml
 
     # Upload artifact
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
     # Build the book
     - name: Build the book
       run: |
-        jupyter-book build .
+        jupyter-book build . --builder dirhtml
 
     # Push the book's HTML to github-pages
     - name: GitHub Pages action


### PR DESCRIPTION
This updates our link generation so that pages use folder names instead of `pagename.html` convention. This is more common in modern website workflows, and leads to more memorable URLs. It is also going to be the default behavior in Jupyter Book 2.

So for example:

- Old: `https://jupyter.org/governance/list_of_standing_committees_and_working_groups.html`
- This PR: `https://jupyter.org/governance/list_of_standing_committees_and_working_groups`

This will break any pre-existing _direct_ URLs to our governance docs, but it's also a more future-proof decision that we'll only need to make once.

### Suggest we hold off until https://github.com/jupyter/governance/pull/266#issuecomment-2675919190 is resolve or deemed impossible