### PR TITLE
Add to governance that packages must be under the Jupyter PyPi Organisation

### DIFF
--- a/software_subprojects.md
+++ b/software_subprojects.md
@@ -13,6 +13,8 @@ Unless the [Software Steering Council (SSC)](./software_steering_council.md) or 
 - Follow the Jupyter [trademark, branding, and intellectual property guidelines](./trademarks.md).
 - Conduct its activities in a manner that is open, transparent, and inclusive. This includes coordinating with the SSC and EC on mechanisms for information flow and updates to the broader community.
 - Maintain Subproject source code on GitHub in the [Project Jupyter GitHub enterprise organization](https://github.com/enterprises/jupyter).
+- Ensure that Python packages published on PyPI are under the [Jupyter PyPI
+  organisation](https://pypi.org/org/jupyter/).
 - Maintain a publicly visible Team Compass with a list of the Subproject Council members.
 
 ## Incubator Subprojects


### PR DESCRIPTION
_ This is still in progress, but is important as if all maintainers of the project left and it is not under the org, we do lose access. Which is already the case._

Jupyter has [a PyPI organization here](https://pypi.org/org/jupyter/) which allows is to control access, control, and authenticates any packages that are underneath it. Using the organization ensures that the project still has the ability to influence a PyPI package even if others that maintain it stop doing so.

### Related issues

- https://github.com/jupyter-governance/ec-team-compass/issues/39
- https://github.com/jupyter/security/issues/61

### Executive Council Votes

@afshin 
 - [x] yes
 - [ ] no
 - [ ] abstain

@jasongrout 
 - [x] yes
 - [ ] no
 - [ ] abstain

@choldgraf 
 - [x] yes
 - [ ] no
 - [ ] abstain

@Ruv7 
 - [ ] yes
 - [ ] no
 - [x] abstain

@Zsailer 
 - [x] yes
 - [ ] no
 - [ ] abstain

@rpwagner 
 - [x] yes
 - [ ] no
 - [ ] abstain

### Software Steering Council votes

DEI Standing Committee: Martha Cryan @marthacryan
- [x] yes
- [ ] no
- [ ] abstain

Jupyter Accessibility: Gabriel Fouasnon @gabalafou
- [ ] yes
- [ ] no
- [ ] abstain

Jupyter Book: Angus Hollands @agoose77
- [x] yes
- [ ] no
- [ ] abstain

Jupyter Foundations and Standards: Paul Ivanov @ivanov
- [x] yes
- [ ] no
- [ ] abstain

Jupyter Frontends: Jérémy Tuloup @jtpio
- [x] yes
- [ ] no
- [ ] abstain

Jupyter Kernels: Johan Mabille @johanmabille
- [x] yes
- [ ] no
- [ ] abstain

Jupyter Security: (currently vacant?)

Jupyter Server: Vidar Fauske @vidartf
- [x] yes
- [ ] no
- [ ] abstain

Jupyter Widgets: Sylvain Corlay @SylvainCorlay
- [ ] yes
- [ ] no
- [ ] abstain

JupyterHub and Binder: Min Ragan-Kelley @minrk
- [x] yes
- [ ] no
- [ ] abstain

Voilà: Martin Renou @martinRenou
- [x] yes
- [ ] no
- [ ] abstain
