### PR TITLE
Add a note about `jupyter-incubation` being due a review

### DIFF
--- a/newsubprojects.md
+++ b/newsubprojects.md
@@ -25,7 +25,6 @@ There are two ways that new Subprojects are created:
     * e.g., when contributors to a third-party project submit an incorporation
       proposal and receive approval from the Steering Council
 
-
 Note that projects in [github.com/jupyter-incubator](https://github.com/jupyter-incubator)
 are **not** considered officially supported and maintained Subprojects until they
 meet the criteria below and go through the incorporation process detailed later in

--- a/newsubprojects.md
+++ b/newsubprojects.md
@@ -4,12 +4,11 @@ This document describes the process by which new Subprojects are created in or
 moved to these organizations from other locations. For a list of current sub-projects in the Jupyter Community, see [the list of sub-projects](list_of_subprojects.md).
 
 :::{attention}
-The process for incubation under the `jupyter-incubator` organization is due
-a review and may contain links to archived repositories and wording referring
-to the previous Jupyter governance model.
-For guidance on the practical aspects in the interim, you can open an issue on the the Jupyter
-[Software Steering Council](https://github.com/jupyter/software-steering-council-team-compass/)
-team compass describing your proposal and the aspects that you need help with.
+The process for incubation under the `jupyter-incubator` organization is outdated.
+It may contain links to archived repositories and wording that refers to an old version of Jupyter's governance model.
+We aim to review this language and update them with Jupyter's new operating structure.
+
+For guidance in the interim, open an issue on the the Jupyter [Software Steering Council team compass](https://github.com/jupyter/software-steering-council-team-compass/) with any questions or proposals.
 :::
 
 There are two ways that new Subprojects are created:

--- a/newsubprojects.md
+++ b/newsubprojects.md
@@ -3,6 +3,15 @@
 This document describes the process by which new Subprojects are created in or
 moved to these organizations from other locations. For a list of current sub-projects in the Jupyter Community, see [the list of sub-projects](list_of_subprojects.md).
 
+:::{attention}
+The process for incubation under the `jupyter-incubator` organization is due
+a review and may contain links to archived repositories and wording referring
+to the previous Jupyter governance model.
+For guidance on the practical aspects in the interim, you can open an issue on the the Jupyter
+[Software Steering Council](https://github.com/jupyter/software-steering-council-team-compass/)
+team compass describing your proposal and the aspects that you need help with.
+:::
+
 There are two ways that new Subprojects are created:
 
 1. [Direct Subproject creation](#direct-subproject-creation)
@@ -15,6 +24,7 @@ There are two ways that new Subprojects are created:
       organizations and receive approval from the Steering Council
     * e.g., when contributors to a third-party project submit an incorporation
       proposal and receive approval from the Steering Council
+
 
 Note that projects in [github.com/jupyter-incubator](https://github.com/jupyter-incubator)
 are **not** considered officially supported and maintained Subprojects until they

--- a/newsubprojects.md
+++ b/newsubprojects.md
@@ -4,7 +4,7 @@ This document describes the process by which new Subprojects are created in or
 moved to these organizations from other locations. For a list of current sub-projects in the Jupyter Community, see [the list of sub-projects](list_of_subprojects.md).
 
 :::{attention}
-The process for incubation under the `jupyter-incubator` organization is outdated.
+The process for incubation under the [`jupyter-incubator` organization](https://github.com/jupyter-incubator) is outdated.
 It may contain links to archived repositories and wording that refers to an old version of Jupyter's governance model.
 We aim to review this language and update them with Jupyter's new operating structure.
 


### PR DESCRIPTION
This is a hotfix for the incubation docs being completely outdated and therefore discouraging contributions of new repositories/subprojects
- https://github.com/jupyter/governance/issues/256
- https://github.com/jupyter/software-steering-council-team-compass/issues/24

Since the substantial changes will need SSC approval, I am proposing to add this note which does not modify the process itself (so does not need an SSC approval in my understanding).