### PR TITLE
Add Jake to Jupyter Foundation board as ec member

### DIFF
--- a/docs/_data/contributors.yml
+++ b/docs/_data/contributors.yml
@@ -131,6 +131,8 @@ authors:
       - team: executive_council
         term: "2026-2027"
       - team: media_strategy_working_group
+      - team: jupyter_foundation
+        organization: Executive Council
 
   - id: jasongrout
     name: Jason Grout


### PR DESCRIPTION
I noticed Jake was not listed as an [EC foundation board member](https://jupyter.org/governance/people/#jupyter-foundation-governing-board). This should fix it.

CC @jake-stack